### PR TITLE
Fix URL redirect issue by updating URLs

### DIFF
--- a/lib/game.js
+++ b/lib/game.js
@@ -55,7 +55,7 @@ function Game(game) {
     },
   };
 
-  this.urlRoot = 'http://www.mlb.com/gdcross' + game.game_data_directory;
+  this.urlRoot = 'http://gd.mlb.com' + game.game_data_directory;
 
   // Assuming the start is always given in eastern time
   var startString = game.time_date + game.ampm;

--- a/lib/gameday.js
+++ b/lib/gameday.js
@@ -8,7 +8,7 @@ module.exports = {
 
 function games() {
   var today = new Date();
-  var urlBase = sprintf('http://mlb.mlb.com/gdcross/components/game/mlb/' +
+  var urlBase = sprintf('http://gd.mlb.com/components/game/mlb/' +
     'year_%d/month_%02d/day_%02d/',
     today.getFullYear(), today.getMonth() + 1, today.getDate());
   var masterScoreboardUrl = urlBase + 'master_scoreboard.xml';


### PR DESCRIPTION
The www.mlb.com/gdcross and mlb.mlb.com/gdcross URLs now redirect to gd.mlb.com, which breaks playball. Updating to the new correct URLs.