### PR TITLE
Fix multiple favorites configuration in PowerShell

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -126,7 +126,7 @@ function serialize(value) {
 
 function deserialize(key, value) {
   if (value && schema[key]?.type === 'array') {
-    return value.split(/\s*,\s*/);
+    return value.split(/[\s,]+/);
   }
   return value;
 }


### PR DESCRIPTION
PowerShell treats commas as array separators, causing 'LAD,PHI' to be passed as two separate arguments. Commander.js joins these with spaces, creating 'LAD PHI' instead of 'LAD,PHI'.

Updated deserialize() regex from /\s*,\s*/ to /[\s,]+/ to split on both commas and whitespace, fixing the issue for PowerShell users.

Fixes #37