### PR TITLE
Add optional title setting for the current game

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ key | description | default | allowed values
 `color.strike-out` | Color of result where play ends on a strike (strike out) in list of plays in game view | red | _See above_
 `color.walk` | Color of result where play ends on a ball (walk, hit by pitch) in list of plays in game view | green | _See above_
 `favorites` | Teams to highlight in schedule and standings views | | Any one of the following: `ATL`, `AZ`, `BAL`, `BOS`, `CHC`, `CIN`, `CLE`, `COL`, `CWS`, `DET`, `HOU`, `KC`, `LAA`, `LAD`, `MIA`, `MIL`, `MIN`, `NYM`, `NYY`, `OAK`, `PHI`, `PIT`, `SD`, `SEA`, `SF`, `STL`, `TB`, `TEX`, `TOR`, `WSH`. Or a comma-separated list of multiple (e.g. `SEA,MIL`)
+`title` | If enabled, the terminal title will be set to the score of the current game | `false` | `false`, `true`
 
 ### Development
 ```

--- a/src/components/FinishedGame.jsx
+++ b/src/components/FinishedGame.jsx
@@ -1,7 +1,11 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
-import { selectLineScore, selectTeams, selectDecisions, selectBoxscore, selectGameStatus } from '../features/games.js';
+
 import LineScore from './LineScore.js';
+
+import { get } from '../config.js';
+import { selectLineScore, selectTeams, selectDecisions, selectBoxscore, selectGameStatus } from '../features/games.js';
+import { resetTitle, setTitle } from '../screen.js';
 
 const getPlayer = (id, boxscore) => {
   const homePlayer = boxscore.home?.players?.['ID' + id];
@@ -53,6 +57,21 @@ function FinishedGame() {
   const linescore = useSelector(selectLineScore);
   const status = useSelector(selectGameStatus);
   const teams = useSelector(selectTeams);
+
+  useEffect(() => {
+    if (get('title')) {
+      const homeRuns = linescore.teams['home'].runs;
+      const awayRuns = linescore.teams['away'].runs;
+      const home = teams.home.abbreviation;
+      const away = teams.away.abbreviation;
+
+      setTitle(`${away} ${awayRuns} - ${home} ${homeRuns} F`);
+
+      return () => {
+        resetTitle();
+      };
+    }
+  }, [get, linescore, resetTitle, setTitle, teams]);
 
   const awayTeam = `${teams.away.teamName}\n(${teams.away.record.wins}-${teams.away.record.losses})`;
   const homeTeam = `${teams.home.teamName}\n(${teams.home.record.wins}-${teams.home.record.losses})`;

--- a/src/components/LiveGame.jsx
+++ b/src/components/LiveGame.jsx
@@ -25,11 +25,19 @@ function LiveGame()  {
       const home = teams.home.abbreviation;
       const away = teams.away.abbreviation;
 
-      const currentInning = linescore.currentInning;
       let inning = '';
-      if (currentInning && gameStatus.detailedState !== 'Warmup') {
-        const upDown = linescore.isTopInning ? '▲' : '▼';
-        inning = ` ${upDown} ${currentInning}`;
+      if (gameStatus.detailedState === 'Postponed') {
+        inning = 'PPD';
+      } else if (gameStatus.detailedState === 'Cancelled') {
+        inning = 'C';
+      } else if (gameStatus.detailedState === 'Final') {
+        inning = 'F';
+      } else if (gameStatus.detailedState !== 'Pre-Game' && gameStatus.detailedState !== 'Warmup') {
+        const currentInning = linescore.currentInning;
+        if (currentInning) {
+          const upDown = linescore.isTopInning ? '▲' : '▼';
+          inning = ` ${upDown} ${currentInning}`;
+        }
       }
 
       setTitle(`${away} ${awayRuns} - ${home} ${homeRuns}${inning}`);

--- a/src/components/LiveGame.jsx
+++ b/src/components/LiveGame.jsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useEffect } from 'react';
+import { useSelector } from 'react-redux';
 
 import Count from './Count.js';
 import Bases from './Bases.js';
@@ -8,7 +9,37 @@ import AtBat from './AtBat.js';
 import AllPlays from './AllPlays.js';
 import InningDisplay from './InningDisplay.js';
 
+import { get } from '../config.js';
+import { selectGameStatus, selectLineScore, selectTeams } from '../features/games.js';
+import { resetTitle, setTitle } from '../screen.js';
+
 function LiveGame()  {
+  const gameStatus = useSelector(selectGameStatus);
+  const linescore = useSelector(selectLineScore);
+  const teams = useSelector(selectTeams);
+
+  useEffect(() => {
+    if (get('title')) {
+      const homeRuns = linescore.teams['home'].runs;
+      const awayRuns = linescore.teams['away'].runs;
+      const home = teams.home.abbreviation;
+      const away = teams.away.abbreviation;
+
+      const currentInning = linescore.currentInning;
+      let inning = '';
+      if (currentInning && gameStatus.detailedState !== 'Warmup') {
+        const upDown = linescore.isTopInning ? '▲' : '▼';
+        inning = ` ${upDown} ${currentInning}`;
+      }
+
+      setTitle(`${away} ${awayRuns} - ${home} ${homeRuns}${inning}`);
+
+      return () => {
+        resetTitle();
+      };
+    }
+  }, [gameStatus, get, linescore, resetTitle, setTitle, teams]);
+
   return (
     <element>
       <element top={0} left={1} width='100%-1' height={3}>

--- a/src/components/PreviewGame.jsx
+++ b/src/components/PreviewGame.jsx
@@ -1,7 +1,10 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSelector } from 'react-redux';
 import { format } from 'date-fns';
+
+import { get } from '../config.js';
 import { selectTeams, selectVenue, selectStartTime, selectBoxscore, selectProbablePitchers, selectGameStatus } from '../features/games.js';
+import { resetTitle, setTitle } from '../screen.js';
 
 const formatPitcherName = (pitcher) => {
   let display = pitcher.person.fullName;
@@ -42,6 +45,29 @@ function PreviewGame() {
   const away = formatTeam(teams, probables, boxscore, 'away');
   const home = formatTeam(teams, probables, boxscore, 'home');
   const formattedStart = status.startTimeTBD ? 'Start time TBD' : format(new Date(startTime), 'MMMM d, yyy p');
+
+  useEffect(() => {
+    if (get('title')) {
+      const home = teams.home.abbreviation;
+      const away = teams.away.abbreviation;
+
+      // Only show the date if it's not today.
+      const startDate = new Date(startTime);
+      const today = format(new Date(), 'yyyy-DDD');
+      const gameDay = format(startDate, 'yyyy-DDD');
+      let start = format(startDate, 'p');
+      if (today !== gameDay) {
+        start = `${format(startDate, 'MMMM d, yyy')} ${start}`;
+      }
+
+      setTitle(`${away} - ${home} @ ${start}`);
+
+      return () => {
+        resetTitle();
+      };
+    }
+  }, [get, resetTitle, setTitle, startTime, teams]);
+
   return (
     <element>
       <element height='60%'>

--- a/src/config.js
+++ b/src/config.js
@@ -110,6 +110,10 @@ const schema = {
     },
     default: []
   },
+  'title': {
+    type: 'boolean',
+    default: false,
+  }
 };
 
 const config = new Conf({
@@ -127,6 +131,8 @@ function serialize(value) {
 function deserialize(key, value) {
   if (value && schema[key]?.type === 'array') {
     return value.split(/\s*,\s*/);
+  } else if (schema[key]?.type === 'boolean') {
+    return value === 'true';
   }
   return value;
 }

--- a/src/screen.js
+++ b/src/screen.js
@@ -2,13 +2,15 @@ import blessed from 'blessed';
 
 let screen;
 
+const DEFAULT_TITLE = 'Playball!';
+
 function getScreen() {
   if (screen === undefined) {
     screen = blessed.screen({
       autoPadding: true,
       debug: true,
       smartCSR: true,
-      title: 'Playball!',
+      title: DEFAULT_TITLE,
       handleUncaughtExceptions: false,
     });
     
@@ -18,5 +20,12 @@ function getScreen() {
   return screen;
 }
 
+export function resetTitle() {
+  getScreen().title = DEFAULT_TITLE;
+}
+
+export function setTitle(title) {
+  getScreen().title = title;
+}
 
 export default getScreen;


### PR DESCRIPTION
This adds a new boolean `title` configuration setting that, when enabled, will set the terminal title to the score of the current game. It is off by default.

- Active games will look like this: `DET 2 - CLE 1 ▲ 7`
- Active games in warmup will look like this: `SD 0 - CHC 0`
- Preview games will look like this: `BOS - NYY @ 5:08 PM`