### PR TITLE
fix: set language and allow override at build for docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 FROM node:latest
 
+ARG LANG=C.UTF-8
+ARG LC_ALL=C.UTF-8
+
+ENV LANG=${LANG}
+ENV LC_ALL=${LC_ALL}
+
 WORKDIR /usr/src/playball
 
 COPY . .

--- a/README.md
+++ b/README.md
@@ -30,6 +30,14 @@ $ docker build -t playball .
 $ docker run -it --rm --name playball playball:latest
 ```
 
+#### Build options
+
+Update the language encoding of by adding `--build-args`
+
+```
+$ docker build --build-arg LANG=en_US.UTF-8 -t playball .
+```
+
 ### Keys
 #### Global
 key | action


### PR DESCRIPTION
# Issue

When running via docker, some characters show as `?` because language encoding is not set

<img width="1189" height="677" alt="Screenshot from 2025-10-02 17-21-48" src="https://github.com/user-attachments/assets/8cee5bf8-57b8-4667-b3b7-7bcd6c34c3e5" />




# Fix

Allow language encoding to be set at build time, default to utf-8

# Testing

Build using

```
$ docker build -t playball .
$ docker run -it --rm --name playball playball:latest
```


<img width="1189" height="677" alt="Screenshot from 2025-10-02 17-25-30" src="https://github.com/user-attachments/assets/0f6627a5-beb0-4fbf-bcb9-03bc0d6215bb" />
