### PR TITLE
[docs] have docker container use local timesystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ playball
 ### Docker
 ```
 $ docker build -t playball .
-$ docker run -it --rm --name playball playball:latest
+$ docker run -it --rm --tz local --name playball playball:latest
 ```
 
 ### Keys


### PR DESCRIPTION
When running from a container as currently instructed, playball will determine 'Today' by UTC. In this situation, users in the continental US would see 'tomorrow's games as early as 4pm 'today'. They'd potentially see 'No games' when playball starts and think it was broken. Or have to switch to the previous day to see games live in their current evening.

Adding the `--tz local` flag will match the container to the local system's timezone. playball's Today will then more closely matching user expectations.

I haven't used the non-containerized version. For consistency it would be worth verifying that the local timezone determines Today there as well.