### PR TITLE
feat: show replay and ABS challenge counts in line score

### DIFF
--- a/src/components/LineScore.jsx
+++ b/src/components/LineScore.jsx
@@ -1,7 +1,21 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-import { selectLineScore, selectTeams } from '../features/games.js';
+import { selectLineScore, selectTeams, selectReview, selectAbsChallenges, selectGameStatus } from '../features/games.js';
+
+// Visual gap separating the R/H/E block from the challenge columns.
+const CHALLENGE_GAP = '      ';
+
+// Renders a run of glyphs from [count, glyph] segments, e.g. ●●○.
+const glyphs = (...segments) =>
+  segments.map(([count, glyph]) => glyph.repeat(Math.max(0, count))).join('');
+
+// ● = remaining, ○ = used (replay challenges expose no success/fail outcome).
+const reviewCircles = (c) => glyphs([c.remaining, '●'], [c.used, '○']);
+
+// ● = remaining, ○ = used successfully, × = used and lost.
+const absCircles = (c) =>
+  glyphs([c.remaining, '●'], [c.usedSuccessful, '○'], [c.usedFailed, '×']);
 
 const getRuns = (inning, homeAway, isFinal) => {
   const runs = inning[homeAway].runs;
@@ -26,6 +40,13 @@ const getTeamLine = (linescore, totalInnings, homeAway, final) => (
 function LineScore({ align, final }) {
   const linescore = useSelector(selectLineScore);
   const teams = useSelector(selectTeams);
+  const review = useSelector(selectReview);
+  const absChallenges = useSelector(selectAbsChallenges);
+  const status = useSelector(selectGameStatus);
+
+  // A finished game can still be rendered by LiveGame (which doesn't pass
+  // `final`), so derive game-over from status rather than trusting the prop.
+  const isOver = final || status?.abstractGameCode === 'F';
 
   const currentInning = linescore.currentInning;
   if (!currentInning) {
@@ -36,9 +57,29 @@ function LineScore({ align, final }) {
   const home = teams.home.abbreviation;
   const away = teams.away.abbreviation;
   const teamNameLength = 3;
-  let str = ''.padEnd(teamNameLength) + Array.from(Array(totalInnings).keys()).map(i => (i + 1).toString().padStart(2)).join(' ') + '   {bold}R{/bold}  H  E\n' + 
-    away.padEnd(teamNameLength) + getTeamLine(linescore, totalInnings, 'away', final) + '\n' +
-    home.padEnd(teamNameLength) + getTeamLine(linescore, totalInnings, 'home', final);
+
+  // Build only the challenge columns whose data is present (and only while the
+  // game is live — they're not meaningful once it's final). Each column's width
+  // is fixed across all three rows so the grid stays aligned under `align`.
+  const columns = [];
+  if (!isOver && review?.away && review?.home) {
+    columns.push({ header: 'C', away: reviewCircles(review.away), home: reviewCircles(review.home) });
+  }
+  if (!isOver && absChallenges?.away && absChallenges?.home) {
+    columns.push({ header: 'ABS', away: absCircles(absChallenges.away), home: absCircles(absChallenges.home) });
+  }
+  columns.forEach(col => {
+    col.width = Math.max(col.header.length, col.away.length, col.home.length);
+  });
+
+  const challengeSegment = (rowKey) =>
+    columns.length === 0
+      ? ''
+      : CHALLENGE_GAP + columns.map(col => col[rowKey].padEnd(col.width)).join(' ');
+
+  const str = ''.padEnd(teamNameLength) + Array.from(Array(totalInnings).keys()).map(i => (i + 1).toString().padStart(2)).join(' ') + '   {bold}R{/bold}  H  E' + challengeSegment('header') + '\n' +
+    away.padEnd(teamNameLength) + getTeamLine(linescore, totalInnings, 'away', final) + challengeSegment('away') + '\n' +
+    home.padEnd(teamNameLength) + getTeamLine(linescore, totalInnings, 'home', final) + challengeSegment('home');
   return (
     <box align={align} content={str} tags wrap={false} />
   );

--- a/src/features/games.js
+++ b/src/features/games.js
@@ -219,4 +219,14 @@ export const selectProbablePitchers = createSelector(
   gameData => gameData.probablePitchers
 );
 
+export const selectReview = createSelector(
+  selectGameData,
+  gameData => gameData.review
+);
+
+export const selectAbsChallenges = createSelector(
+  selectGameData,
+  gameData => gameData.absChallenges
+);
+
 export default gamesSlice.reducer;


### PR DESCRIPTION
Add selectReview and selectAbsChallenges selectors and render per-team challenge columns (C / ABS) beside R/H/E while a game is live, using ● remaining / ○ used / × failed glyphs.