### PR TITLE
Show delayed, cancelled, and postponed game statuses

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "babel src --out-dir dist --watch",
     "prepublishOnly": "npm run build",
     "react-devtools": "react-devtools",
-    "test": "echo \"No tests yet\""
+    "test": "node test/gameStatus.test.js"
   },
   "bin": {
     "playball": "./bin/playball.js"

--- a/src/components/Game.jsx
+++ b/src/components/Game.jsx
@@ -12,8 +12,10 @@ import {
 import PreviewGame from './PreviewGame.js';
 import LiveGame from './LiveGame.js';
 import FinishedGame from './FinishedGame.js';
+import StatusGame from './StatusGame.js';
 
 import log from '../logger.js';
+import {getExceptionalGameState} from '../gameStatus.js';
 
 function Game() {
   const dispatch = useDispatch();
@@ -46,7 +48,10 @@ function Game() {
     return <element />;
   }
 
-  let Wrapped = null;
+  let Wrapped;
+  if (getExceptionalGameState(game.gameData?.status)) {
+    return <element><StatusGame game={game} /></element>;
+  }
   switch (game.gameData?.status?.abstractGameCode) {
   case 'P':
     Wrapped = PreviewGame;
@@ -60,7 +65,7 @@ function Game() {
   }
 
   return (
-    <element><Wrapped /></element>
+    <element>{Wrapped && <Wrapped />}</element>
   );
 }
 

--- a/src/components/GameList.jsx
+++ b/src/components/GameList.jsx
@@ -12,10 +12,12 @@ import {
   setDate
 } from '../features/schedule.js';
 import {teamFavoriteStar} from '../utils.js';
+import {formatAnnouncedGameTime, formatExceptionalGameStatus} from '../gameStatus.js';
+import {compareGameInnings} from '../gameSort.js';
 import Grid from './Grid.js';
 import useKey from '../hooks/useKey.js';
 
-const formatGame = game => {
+const formatGame = (game, scheduleDate) => {
   const startTime = game.status.startTimeTBD ? 'TBD' : format(new Date(game.gameDate), 'p');
   const start = (game.doubleHeader === 'Y' && game.gameNumber > 1) ? 
     'Game ' + game.gameNumber :
@@ -27,6 +29,15 @@ const formatGame = game => {
   let content = [start, teamName(game.teams.away), teamName(game.teams.home)];
   const gameState = game.status.abstractGameCode;
   const detailedState = game.status.detailedState;
+  const exceptionalStatus = formatExceptionalGameStatus(game.status);
+  if (exceptionalStatus) {
+    const announcedTime = formatAnnouncedGameTime(game, scheduleDate);
+    content[0] = exceptionalStatus;
+    if (announcedTime) {
+      content[0] += ' | ' + announcedTime;
+    }
+    return content.map(s => ' ' + s).join('\n');
+  }
   switch (gameState) {
   case 'P':
     break;
@@ -84,20 +95,6 @@ const GAME_STATE_ORDER = {
 };
 function compareGameState(a, b) {
   return GAME_STATE_ORDER[a.status.abstractGameCode] - GAME_STATE_ORDER[b.status.abstractGameCode];
-}
-
-function compareGameInnings(a, b) {
-  const inningCompare = b.linescore.currentInning - a.linescore.currentInning;
-  if (inningCompare !== 0) {
-    return inningCompare;
-  }
-  if (a.isTopInning && !b.isTopInning) {
-    return -1;
-  }
-  if (b.isTopInning && !a.isTopInning) {
-    return 1;
-  }
-  return 0;
 }
 
 function compareGames(a, b) {
@@ -159,7 +156,7 @@ function GameList({ onGameSelect }) {
         {(schedule && games.length === 0) && <box {...messageStyle} content='No games today' />}
         {(schedule && games.length > 0) && (
           <Grid 
-            items={games.map(formatGame)}
+            items={games.map(game => formatGame(game, date))}
             itemHeight={5}
             itemMinWidth={34}
             onSelect={handleGameSelect}

--- a/src/components/StatusGame.jsx
+++ b/src/components/StatusGame.jsx
@@ -1,0 +1,44 @@
+import React, {useEffect} from 'react';
+import PropTypes from 'prop-types';
+import {format} from 'date-fns';
+
+import {get} from '../config.js';
+import {formatExceptionalGameStatus, getAnnouncedGameTime} from '../gameStatus.js';
+import {resetTitle, setTitle} from '../screen.js';
+
+const teamName = (team, fallback) => team?.name || team?.teamName || team?.abbreviation || fallback;
+
+function StatusGame({game}) {
+  const status = game.gameData?.status || {};
+  const teams = game.gameData?.teams || {};
+  const away = teamName(teams.away, 'Away');
+  const home = teamName(teams.home, 'Home');
+  const statusText = formatExceptionalGameStatus(status);
+  const announcedTime = getAnnouncedGameTime(game);
+  const timeText = announcedTime
+    ? `\nAnnounced time: ${format(new Date(announcedTime), 'MMMM d, yyy p')}`
+    : '';
+
+  useEffect(() => {
+    if (get('title')) {
+      const awayTitle = teams.away?.abbreviation || away;
+      const homeTitle = teams.home?.abbreviation || home;
+      setTitle(`${awayTitle} - ${homeTitle} | ${statusText}`);
+      return () => resetTitle();
+    }
+  }, [away, home, statusText, teams]);
+
+  return (
+    <element height='60%'>
+      <box content={away} width='33%-1' top='50%' align='center' />
+      <box content={`\nvs.\n\n${statusText}${timeText}`} width='33%-1' left='33%' top='50%' align='center' />
+      <box content={home} width='34%' top='50%' left='66%' align='center' />
+    </element>
+  );
+}
+
+StatusGame.propTypes = {
+  game: PropTypes.object.isRequired,
+};
+
+export default StatusGame;

--- a/src/gameSort.js
+++ b/src/gameSort.js
@@ -1,0 +1,23 @@
+export function compareGameInnings(a, b) {
+  if (!a.linescore && !b.linescore) {
+    return 0;
+  }
+  if (!a.linescore) {
+    return 1;
+  }
+  if (!b.linescore) {
+    return -1;
+  }
+
+  const inningCompare = b.linescore.currentInning - a.linescore.currentInning;
+  if (inningCompare !== 0) {
+    return inningCompare;
+  }
+  if (a.isTopInning && !b.isTopInning) {
+    return -1;
+  }
+  if (b.isTopInning && !a.isTopInning) {
+    return 1;
+  }
+  return 0;
+}

--- a/src/gameStatus.js
+++ b/src/gameStatus.js
@@ -1,0 +1,71 @@
+import {format, isSameDay} from 'date-fns';
+
+const DELAYED = /^delayed(?: start)?(?:\b|$)/i;
+const IN_GAME_DELAY = /^in progress\s*-\s*delay(?:ed)?(?:\b|$)/i;
+const CANCELLED = /^cancel(?:l)?ed(?:\b|$)/i;
+const POSTPONED = /^postponed(?:\b|$)/i;
+
+const matches = (value, pattern) => typeof value === 'string' && pattern.test(value.trim());
+
+export function getExceptionalGameState(status = {}) {
+  const states = [status.detailedState, status.abstractGameState];
+
+  if (status.codedGameState === 'C') {
+    return 'cancelled';
+  }
+  if (status.codedGameState === 'D') {
+    return 'postponed';
+  }
+  if (states.some(state => matches(state, CANCELLED))) {
+    return 'cancelled';
+  }
+  if (states.some(state => matches(state, POSTPONED))) {
+    return 'postponed';
+  }
+  if (states.some(state => matches(state, DELAYED) || matches(state, IN_GAME_DELAY))) {
+    return 'delayed';
+  }
+  return null;
+}
+
+export function formatExceptionalGameStatus(status = {}) {
+  const state = getExceptionalGameState(status);
+  if (!state) {
+    return null;
+  }
+
+  const detailedState = status.detailedState?.trim();
+  const statePattern = state === 'delayed'
+    ? [DELAYED, IN_GAME_DELAY]
+    : [state === 'cancelled' ? CANCELLED : POSTPONED];
+  const fallback = state === 'delayed'
+    ? 'Delayed'
+    : state.charAt(0).toUpperCase() + state.slice(1);
+  let text = detailedState && statePattern.some(pattern => matches(detailedState, pattern))
+    ? detailedState
+    : fallback;
+  const reason = status.reason?.trim();
+  if (reason && !text.toLowerCase().includes(reason.toLowerCase())) {
+    text += ' | ' + reason;
+  }
+  return text;
+}
+
+export function getAnnouncedGameTime(game = {}) {
+  return game.resumeDate
+    || game.rescheduleDate
+    || game.gameData?.datetime?.resumeDateTime
+    || game.gameData?.datetime?.rescheduleDateTime
+    || null;
+}
+
+export function formatAnnouncedGameTime(game = {}, scheduleDate) {
+  const announcedTime = getAnnouncedGameTime(game);
+  if (!announcedTime) {
+    return null;
+  }
+
+  const announcedDate = new Date(announcedTime);
+  const timeFormat = scheduleDate && isSameDay(announcedDate, scheduleDate) ? 'p' : 'MMM d p';
+  return format(announcedDate, timeFormat);
+}

--- a/test/gameStatus.test.js
+++ b/test/gameStatus.test.js
@@ -1,0 +1,100 @@
+import assert from 'assert';
+
+import {
+  formatAnnouncedGameTime,
+  formatExceptionalGameStatus,
+  getAnnouncedGameTime,
+  getExceptionalGameState
+} from '../src/gameStatus.js';
+import {compareGameInnings} from '../src/gameSort.js';
+
+assert.strictEqual(getExceptionalGameState({detailedState: 'Delayed Start'}), 'delayed');
+assert.strictEqual(getExceptionalGameState({detailedState: 'Delayed: Rain'}), 'delayed');
+assert.strictEqual(getExceptionalGameState({detailedState: 'Delayed Start: Rain'}), 'delayed');
+assert.strictEqual(getExceptionalGameState({detailedState: 'In Progress - Delay'}), 'delayed');
+assert.strictEqual(getExceptionalGameState({detailedState: 'In Progress - Delay: Rain'}), 'delayed');
+assert.strictEqual(getExceptionalGameState({detailedState: 'Cancelled: Rain'}), 'cancelled');
+assert.strictEqual(getExceptionalGameState({detailedState: 'Postponed: Rain'}), 'postponed');
+assert.strictEqual(getExceptionalGameState({codedGameState: 'C'}), 'cancelled');
+assert.strictEqual(getExceptionalGameState({codedGameState: 'D'}), 'postponed');
+assert.strictEqual(
+  getExceptionalGameState({codedGameState: 'C', detailedState: 'Delayed Start'}),
+  'cancelled'
+);
+assert.strictEqual(
+  getExceptionalGameState({codedGameState: 'D', detailedState: 'In Progress - Delay'}),
+  'postponed'
+);
+
+assert.strictEqual(
+  formatExceptionalGameStatus({detailedState: 'Delayed Start: Rain', reason: 'Rain'}),
+  'Delayed Start: Rain'
+);
+assert.strictEqual(
+  formatExceptionalGameStatus({detailedState: 'Delayed Start', reason: 'Rain'}),
+  'Delayed Start | Rain'
+);
+assert.strictEqual(
+  formatExceptionalGameStatus({codedGameState: 'C', reason: 'Rain'}),
+  'Cancelled | Rain'
+);
+
+assert.strictEqual(getAnnouncedGameTime({gameDate: '2026-07-22T23:10:00Z'}), null);
+assert.strictEqual(getAnnouncedGameTime({
+  gameData: {
+    datetime: {dateTime: '2026-07-22T23:10:00Z'},
+    gameInfo: {firstPitch: '2026-07-22T23:15:00Z'}
+  }
+}), null);
+assert.strictEqual(
+  getAnnouncedGameTime({resumeDate: '2026-07-23T00:10:00Z'}),
+  '2026-07-23T00:10:00Z'
+);
+assert.strictEqual(
+  getAnnouncedGameTime({rescheduleDate: '2026-07-24T23:10:00Z'}),
+  '2026-07-24T23:10:00Z'
+);
+assert.strictEqual(
+  getAnnouncedGameTime({gameData: {datetime: {resumeDateTime: '2026-07-23T00:30:00Z'}}}),
+  '2026-07-23T00:30:00Z'
+);
+assert.strictEqual(
+  getAnnouncedGameTime({gameData: {datetime: {rescheduleDateTime: '2026-07-24T23:10:00Z'}}}),
+  '2026-07-24T23:10:00Z'
+);
+const announcedDate = new Date(2026, 6, 24, 19, 10);
+assert.strictEqual(
+  formatAnnouncedGameTime({rescheduleDate: announcedDate.toISOString()}),
+  'Jul 24 7:10 PM'
+);
+const scheduleDate = new Date(2026, 6, 22, 12);
+const sameDayAnnouncedDate = new Date(2026, 6, 22, 14, 5);
+assert.strictEqual(
+  formatAnnouncedGameTime({resumeDate: sameDayAnnouncedDate.toISOString()}, scheduleDate),
+  '2:05 PM'
+);
+const nextDayAnnouncedDate = new Date(2026, 6, 23, 13, 5);
+assert.strictEqual(
+  formatAnnouncedGameTime({rescheduleDate: nextDayAnnouncedDate.toISOString()}, scheduleDate),
+  'Jul 23 1:05 PM'
+);
+
+assert.strictEqual(getExceptionalGameState({detailedState: 'In Progress'}), null);
+assert.strictEqual(formatExceptionalGameStatus({detailedState: 'Final'}), null);
+
+const delayedWithoutLineScore = {
+  name: 'delayed',
+  status: {abstractGameCode: 'L', detailedState: 'In Progress - Delay'}
+};
+const inningOneGame = {name: 'inning 1', linescore: {currentInning: 1}};
+const inningThreeGame = {name: 'inning 3', linescore: {currentInning: 3}};
+const inningFiveGame = {name: 'inning 5', linescore: {currentInning: 5}};
+assert.strictEqual(compareGameInnings(delayedWithoutLineScore, {...delayedWithoutLineScore}), 0);
+assert.strictEqual(compareGameInnings(delayedWithoutLineScore, inningThreeGame), 1);
+assert.strictEqual(compareGameInnings(inningThreeGame, delayedWithoutLineScore), -1);
+assert.deepStrictEqual(
+  [inningOneGame, delayedWithoutLineScore, inningFiveGame].sort(compareGameInnings).map(game => game.name),
+  ['inning 5', 'inning 1', 'delayed']
+);
+
+console.log('Game status regression tests passed');


### PR DESCRIPTION
Closes #52

## What changed

- Display delayed starts and in-game delays in the schedule and game detail views
- Show the delay reason and announced start or resume time when MLB provides one
- Omit the date when the announced time falls on the displayed schedule date
- Display cancelled and postponed games without requiring score data
- Keep live-game sorting deterministic when a delayed game has no linescore

## Root cause

The schedule and detail views only handled standard preview, live, and final states. Exceptional MLB statuses were not rendered separately, and live-game handling assumed linescore data was always available.