### PR TITLE
Show batting, baserunning, fielding, and pitching details in the boxscore

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "babel src --out-dir dist --watch",
     "prepublishOnly": "npm run build",
     "react-devtools": "react-devtools",
-    "test": "node test/gameStatus.test.js"
+    "test": "node test/gameStatus.test.js && node test/boxScore.test.js"
   },
   "bin": {
     "playball": "./bin/playball.js"

--- a/src/boxScore.js
+++ b/src/boxScore.js
@@ -1,0 +1,251 @@
+// e.g. "Struck out for Beavers in the 8th."
+const SUBSTITUTE_NOTE = / for (.+) in the \d+(?:st|nd|rd|th)\.?$/;
+const INFO_INDENT = 4;
+
+/**
+ * Break text into lines that fit a given width, indenting every line after
+ * the first. Words longer than the width are split across lines.
+ * @param {string} text
+ * @param {number} width
+ * @param {number} indent number of spaces to prefix continuation lines with
+ * @returns {string[]} the wrapped lines
+ */
+export function wrapText(text, width, indent = 0) {
+  if (width <= 0) {
+    return [text];
+  }
+  const pad = ' '.repeat(Math.min(indent, width - 1));
+  const lines = [];
+  let line = '';
+  text.split(/\s+/).filter(word => word.length > 0).forEach(word => {
+    if (line === '') {
+      line = (lines.length === 0 ? '' : pad) + word;
+    } else if (line.length + 1 + word.length <= width) {
+      line += ' ' + word;
+    } else {
+      lines.push(line);
+      line = pad + word;
+    }
+    while (line.length > width) {
+      lines.push(line.slice(0, width));
+      line = pad + line.slice(width);
+    }
+  });
+  if (line !== '') {
+    lines.push(line);
+  }
+  return lines;
+}
+
+// Blessed treats braces as markup, and the info text is rendered with tags on
+// so that labels can be bolded.
+function stripTags(text) {
+  return (text || '').replace(/[{}]/g, '');
+}
+
+// Wrap `prefix + text` to the given width, bolding the prefix
+function wrapEntry(prefix, text, width) {
+  const lines = wrapText(`${prefix}${text}`, width, INFO_INDENT);
+  if (lines.length > 0) {
+    lines[0] = `{bold}${lines[0].slice(0, prefix.length)}{/bold}${lines[0].slice(prefix.length)}`;
+  }
+  return lines;
+}
+
+function wrapField(field, width) {
+  const label = stripTags(field.label);
+  const value = stripTags(field.value);
+  return value
+    ? wrapEntry(`${label}: `, value, width)
+    : wrapEntry(label, '', width);
+}
+
+function getBatters(boxscoreTeam) {
+  return Object.values(boxscoreTeam.players)
+    .filter(player => player.battingOrder !== undefined)
+    .sort((a, b) => parseInt(a.battingOrder) - parseInt(b.battingOrder));
+}
+
+// The team notes explain which player each substitute batted or ran for, and
+// are keyed by a letter that appears next to the substitute in the lineup.
+function getNoteLabels(boxscoreTeam, batters, players) {
+  const slotOf = batter => Math.floor(parseInt(batter.battingOrder) / 100);
+  const labels = {};
+  (boxscoreTeam.note || []).forEach(note => {
+    const match = SUBSTITUTE_NOTE.exec(note.value || '');
+    if (!match) {
+      return;
+    }
+    const replacedIdx = batters.findIndex(
+      batter => players[`ID${batter.person.id}`]?.boxscoreName === match[1]
+    );
+    if (replacedIdx < 0) {
+      return;
+    }
+    const slot = slotOf(batters[replacedIdx]);
+    const substitute = batters.find((batter, idx) => (
+      idx > replacedIdx
+      && slotOf(batter) === slot
+      && batter.gameStatus?.isSubstitute
+      && labels[batter.person.id] === undefined
+    ));
+    if (substitute) {
+      labels[substitute.person.id] = note.label;
+    }
+  });
+  return labels;
+}
+
+export function getBatterRows(boxscoreTeam, players) {
+  const batters = getBatters(boxscoreTeam);
+  const noteLabels = getNoteLabels(boxscoreTeam, batters, players);
+  const substituteIndent = Object.keys(noteLabels).length > 0 ? '  ' : ' ';
+  const batterNames = batters.map(batter => {
+    const name = players[`ID${batter.person.id}`].boxscoreName;
+    const positions = batter.allPositions?.map(pos => pos.abbreviation).join('-');
+    const label = noteLabels[batter.person.id];
+    let prefix = '';
+    if (label) {
+      prefix = `${label}-`;
+    } else if (batter.gameStatus?.isSubstitute) {
+      prefix = substituteIndent;
+    }
+    return `${prefix}${name} (${positions})`;
+  });
+  return [
+    ...batters.map((batter, idx) => [
+      batterNames[idx],
+      batter.stats.batting.atBats.toString(),
+      batter.stats.batting.runs.toString(),
+      batter.stats.batting.hits.toString(),
+      batter.stats.batting.rbi.toString(),
+      batter.stats.batting.baseOnBalls.toString(),
+      batter.stats.batting.strikeOuts.toString(),
+      batter.seasonStats.batting.avg,
+      batter.seasonStats.batting.ops,
+    ]),
+    [
+      'Totals',
+      boxscoreTeam.teamStats.batting.atBats.toString(),
+      boxscoreTeam.teamStats.batting.runs.toString(),
+      boxscoreTeam.teamStats.batting.hits.toString(),
+      boxscoreTeam.teamStats.batting.rbi.toString(),
+      boxscoreTeam.teamStats.batting.baseOnBalls.toString(),
+      boxscoreTeam.teamStats.batting.strikeOuts.toString(),
+      '',
+      '',
+    ]
+  ];
+}
+
+export function getPitcherRows(boxscoreTeam, players) {
+  const pitchers = boxscoreTeam.pitchers.map(pitcherId => boxscoreTeam.players['ID' + pitcherId]);
+  const pitcherNames = pitchers.map(pitcher => {
+    const name = players[`ID${pitcher.person.id}`].boxscoreName;
+    const note = pitcher.stats.pitching.note ? ` ${pitcher.stats.pitching.note}` : '';
+    return `${name}${note}`;
+  });
+  return [
+    ...pitchers.map((pitcher, idx) => [
+      pitcherNames[idx],
+      pitcher.stats.pitching.inningsPitched,
+      pitcher.stats.pitching.hits.toString(),
+      pitcher.stats.pitching.runs.toString(),
+      pitcher.stats.pitching.earnedRuns.toString(),
+      pitcher.stats.pitching.baseOnBalls.toString(),
+      pitcher.stats.pitching.strikeOuts.toString(),
+      pitcher.stats.pitching.homeRuns.toString(),
+      pitcher.seasonStats.pitching.era,
+    ]),
+    [
+      'Totals',
+      boxscoreTeam.teamStats.pitching.inningsPitched,
+      boxscoreTeam.teamStats.pitching.hits.toString(),
+      boxscoreTeam.teamStats.pitching.runs.toString(),
+      boxscoreTeam.teamStats.pitching.earnedRuns.toString(),
+      boxscoreTeam.teamStats.pitching.baseOnBalls.toString(),
+      boxscoreTeam.teamStats.pitching.strikeOuts.toString(),
+      boxscoreTeam.teamStats.pitching.homeRuns.toString(),
+      '',
+    ]
+  ];
+}
+
+/**
+ * The extra hitting, baserunning and fielding details that appear below a
+ * team's batting order: doubles, triples, home runs, stolen bases, errors, etc.
+ */
+export function getTeamInfoLines(boxscoreTeam, width) {
+  const lines = [];
+  (boxscoreTeam.note || []).forEach(note => {
+    lines.push(...wrapEntry(`${stripTags(note.label)}-`, stripTags(note.value), width));
+  });
+  (boxscoreTeam.info || []).forEach(section => {
+    if (lines.length > 0) {
+      lines.push('');
+    }
+    lines.push(`{bold}${stripTags(section.title)}{/bold}`);
+    (section.fieldList || []).forEach(field => {
+      lines.push(...wrapField(field, width));
+    });
+  });
+  return lines;
+}
+
+/**
+ * Game wide details that follow the pitching lines: wild pitches, hit batsmen,
+ * pitch counts, umpires, weather, attendance, etc.
+ */
+export function getGameInfoLines(pitchingNotes, gameInfo, width) {
+  const lines = [];
+  (pitchingNotes || []).forEach(note => {
+    lines.push(...wrapText(stripTags(note), width, INFO_INDENT));
+  });
+  if (lines.length > 0 && gameInfo?.length > 0) {
+    lines.push('');
+  }
+  (gameInfo || []).forEach(field => {
+    lines.push(...wrapField(field, width));
+  });
+  return lines;
+}
+
+/**
+ * Build the contents of the box score along with the row each section starts
+ * on. Every section is positioned against the height of the one above it, so
+ * the info text is wrapped here rather than by blessed, whose wrapping happens
+ * too late to be measured.
+ * @param {object} options
+ * @param {object} options.boxscore the away and home boxscore teams
+ * @param {object} options.players the game's players, keyed by `ID<id>`
+ * @param {object[]} options.gameInfo game wide info fields
+ * @param {string[]} options.pitchingNotes
+ * @param {number} options.width the width of the box score, in columns
+ */
+export function getBoxScoreLayout({ boxscore, players, gameInfo, pitchingNotes, width }) {
+  const columnWidth = Math.floor(width / 2) - 1;
+  const teams = ['away', 'home'].reduce((result, side) => ({
+    ...result,
+    [side]: {
+      batterRows: getBatterRows(boxscore[side], players),
+      infoLines: getTeamInfoLines(boxscore[side], columnWidth),
+      pitcherRows: getPitcherRows(boxscore[side], players),
+    }
+  }), {});
+
+  // A table is a header row plus its rows, and a blank row separates sections
+  const tallest = key => Math.max(teams.away[key].length, teams.home[key].length);
+  const teamInfoTop = tallest('batterRows') + 2;
+  const teamInfoHeight = tallest('infoLines');
+  const pitcherTop = teamInfoTop + (teamInfoHeight > 0 ? teamInfoHeight + 1 : 0);
+  const gameInfoTop = pitcherTop + tallest('pitcherRows') + 2;
+
+  return {
+    ...teams,
+    // The game info spans both columns, less a column for the scrollbar
+    gameInfoLines: getGameInfoLines(pitchingNotes, gameInfo, width - 1),
+    teamInfoTop,
+    pitcherTop,
+    gameInfoTop,
+  };
+}

--- a/src/components/BoxScore.jsx
+++ b/src/components/BoxScore.jsx
@@ -1,16 +1,90 @@
-import React from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {useSelector} from 'react-redux';
-import {selectBoxscore, selectPlayers} from '../features/games.js';
+import PropTypes from 'prop-types';
+import {
+  selectBoxscore,
+  selectGameInfo,
+  selectPitchingNotes,
+  selectPlayers,
+} from '../features/games.js';
+import getScreen from '../screen.js';
+import style from '../style/index.js';
+import {wrapText} from '../utils.js';
 import Table from './Table.js';
+
+// e.g. "Struck out for Beavers in the 8th."
+const SUBSTITUTE_NOTE = / for (.+) in the \d+(?:st|nd|rd|th)\.?$/;
+const INFO_INDENT = 4;
+
+// Blessed treats braces as markup, and the info text is rendered with tags on
+// so that labels can be bolded.
+function stripTags(text) {
+  return (text || '').replace(/[{}]/g, '');
+}
+
+// Wrap `prefix + text` to the given width, bolding the prefix
+function wrapEntry(prefix, text, width) {
+  const lines = wrapText(`${prefix}${text}`, width, INFO_INDENT);
+  if (lines.length > 0) {
+    lines[0] = `{bold}${lines[0].slice(0, prefix.length)}{/bold}${lines[0].slice(prefix.length)}`;
+  }
+  return lines;
+}
+
+function wrapField(field, width) {
+  const label = stripTags(field.label);
+  const value = stripTags(field.value);
+  return value
+    ? wrapEntry(`${label}: `, value, width)
+    : wrapEntry(label, '', width);
+}
+
+// The team notes explain which player each substitute batted or ran for, and
+// are keyed by a letter that appears next to the substitute in the lineup.
+function getNoteLabels(boxscoreTeam, batters, players) {
+  const slotOf = batter => Math.floor(parseInt(batter.battingOrder) / 100);
+  const labels = {};
+  (boxscoreTeam.note || []).forEach(note => {
+    const match = SUBSTITUTE_NOTE.exec(note.value || '');
+    if (!match) {
+      return;
+    }
+    const replacedIdx = batters.findIndex(
+      batter => players[`ID${batter.person.id}`]?.boxscoreName === match[1]
+    );
+    if (replacedIdx < 0) {
+      return;
+    }
+    const slot = slotOf(batters[replacedIdx]);
+    const substitute = batters.find((batter, idx) => (
+      idx > replacedIdx
+      && slotOf(batter) === slot
+      && batter.gameStatus?.isSubstitute
+      && labels[batter.person.id] === undefined
+    ));
+    if (substitute) {
+      labels[substitute.person.id] = note.label;
+    }
+  });
+  return labels;
+}
 
 function getBatterRows(boxscoreTeam, players) {
   const batters = Object.values(boxscoreTeam.players)
     .filter(player => player.battingOrder !== undefined)
     .sort((a, b) => parseInt(a.battingOrder) - parseInt(b.battingOrder));
+  const noteLabels = getNoteLabels(boxscoreTeam, batters, players);
+  const substituteIndent = Object.keys(noteLabels).length > 0 ? '  ' : ' ';
   const batterNames = batters.map(batter => {
     const name = players[`ID${batter.person.id}`].boxscoreName;
     const positions = batter.allPositions?.map(pos => pos.abbreviation).join('-');
-    const prefix = batter.gameStatus?.isSubstitute ? ' ' : '';
+    const label = noteLabels[batter.person.id];
+    let prefix = '';
+    if (label) {
+      prefix = `${label}-`;
+    } else if (batter.gameStatus?.isSubstitute) {
+      prefix = substituteIndent;
+    }
     return `${prefix}${name} (${positions})`;
   });
   return [
@@ -72,23 +146,116 @@ function getPitcherRows(boxscoreTeam, players) {
   ];
 }
 
+// The extra hitting, baserunning and fielding details that appear below a
+// team's batting order: doubles, triples, home runs, stolen bases, errors, etc.
+function getTeamInfoLines(boxscoreTeam, width) {
+  const lines = [];
+  (boxscoreTeam.note || []).forEach(note => {
+    lines.push(...wrapEntry(`${stripTags(note.label)}-`, stripTags(note.value), width));
+  });
+  (boxscoreTeam.info || []).forEach(section => {
+    if (lines.length > 0) {
+      lines.push('');
+    }
+    lines.push(`{bold}${stripTags(section.title)}{/bold}`);
+    (section.fieldList || []).forEach(field => {
+      lines.push(...wrapField(field, width));
+    });
+  });
+  return lines;
+}
+
+// Game wide details that follow the pitching lines: wild pitches, hit
+// batsmen, pitch counts, umpires, weather, attendance, etc.
+function getGameInfoLines(pitchingNotes, gameInfo, width) {
+  const lines = [];
+  (pitchingNotes || []).forEach(note => {
+    lines.push(...wrapText(stripTags(note), width, INFO_INDENT));
+  });
+  if (lines.length > 0 && gameInfo?.length > 0) {
+    lines.push('');
+  }
+  (gameInfo || []).forEach(field => {
+    lines.push(...wrapField(field, width));
+  });
+  return lines;
+}
+
+function InfoBox({ lines, ...rest }) {
+  if (lines.length === 0) {
+    return null;
+  }
+  return (
+    <box
+      {...rest}
+      height={lines.length}
+      wrap={false}
+      tags
+      content={lines.join('\n')}
+    />
+  );
+}
+
+InfoBox.propTypes = {
+  lines: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
 function BoxScore({ ...props }) {
   const boxscore = useSelector(selectBoxscore);
   const players = useSelector(selectPlayers);
+  const gameInfo = useSelector(selectGameInfo);
+  const pitchingNotes = useSelector(selectPitchingNotes);
+
+  // The info sections are wrapped by hand so that the height of each one is
+  // known, which is what everything below it gets positioned against.
+  const containerRef = useRef(null);
+  const [width, setWidth] = useState(() => getScreen().width);
+  const measure = useCallback(() => {
+    const measured = containerRef.current?.width;
+    if (measured > 0) {
+      setWidth(measured);
+    }
+  }, []);
+  useEffect(measure);
+  useEffect(() => {
+    const screen = getScreen();
+    screen.on('resize', measure);
+    return () => screen.removeListener('resize', measure);
+  }, [measure]);
+  const columnWidth = Math.floor(width / 2) - 1;
 
   const batterHeader = ['Batters', 'AB', 'R', 'H', 'RBI', 'BB', 'K', 'AVG', 'OPS'];
   const batterWidths = ['auto', 4, 4, 4, 4, 4, 4, 6, 6];
   const awayBatterRows = getBatterRows(boxscore.away, players);
   const homeBatterRows = getBatterRows(boxscore.home, players);
 
+  const teamInfoStart = Math.max(awayBatterRows.length, homeBatterRows.length) + 2;
+  const awayInfoLines = getTeamInfoLines(boxscore.away, columnWidth);
+  const homeInfoLines = getTeamInfoLines(boxscore.home, columnWidth);
+  const teamInfoHeight = Math.max(awayInfoLines.length, homeInfoLines.length);
+
   const pitcherHeader = ['Pitchers', 'IP', 'H', 'R', 'ER', 'BB', 'K', 'HR', 'ERA'];
   const pitcherWidths = ['auto', 5, 4, 4, 4, 4, 4, 4, 6];
-  const pitcherStart = Math.max(awayBatterRows.length, homeBatterRows.length) + 2;
+  const pitcherStart = teamInfoStart + (teamInfoHeight > 0 ? teamInfoHeight + 1 : 0);
   const awayPitcherRows = getPitcherRows(boxscore.away, players);
   const homePitcherRows = getPitcherRows(boxscore.home, players);
 
+  const gameInfoStart = pitcherStart
+    + Math.max(awayPitcherRows.length, homePitcherRows.length) + 2;
+  const gameInfoLines = getGameInfoLines(pitchingNotes, gameInfo, width - 1);
+
   return (
-    <element {...props}>
+    <element
+      {...props}
+      ref={containerRef}
+      focused
+      mouse
+      keys
+      vi
+      scrollable
+      scrollbar={style.scrollbar}
+      alwaysScroll
+    >
       <Table
         top={0}
         left={0}
@@ -105,6 +272,18 @@ function BoxScore({ ...props }) {
         widths={batterWidths}
         rows={homeBatterRows}
       />
+      <InfoBox
+        top={teamInfoStart}
+        left={0}
+        width='50%-1'
+        lines={awayInfoLines}
+      />
+      <InfoBox
+        top={teamInfoStart}
+        left='50%+1'
+        width='50%-1'
+        lines={homeInfoLines}
+      />
       <Table
         top={pitcherStart}
         left={0}
@@ -120,6 +299,12 @@ function BoxScore({ ...props }) {
         headers={pitcherHeader}
         widths={pitcherWidths}
         rows={homePitcherRows}
+      />
+      <InfoBox
+        top={gameInfoStart}
+        left={0}
+        width='100%-1'
+        lines={gameInfoLines}
       />
     </element>
   );

--- a/src/components/BoxScore.jsx
+++ b/src/components/BoxScore.jsx
@@ -1,6 +1,7 @@
 import React, {useCallback, useEffect, useRef, useState} from 'react';
 import {useSelector} from 'react-redux';
 import PropTypes from 'prop-types';
+import {getBoxScoreLayout} from '../boxScore.js';
 import {
   selectBoxscore,
   selectGameInfo,
@@ -9,177 +10,7 @@ import {
 } from '../features/games.js';
 import getScreen from '../screen.js';
 import style from '../style/index.js';
-import {wrapText} from '../utils.js';
 import Table from './Table.js';
-
-// e.g. "Struck out for Beavers in the 8th."
-const SUBSTITUTE_NOTE = / for (.+) in the \d+(?:st|nd|rd|th)\.?$/;
-const INFO_INDENT = 4;
-
-// Blessed treats braces as markup, and the info text is rendered with tags on
-// so that labels can be bolded.
-function stripTags(text) {
-  return (text || '').replace(/[{}]/g, '');
-}
-
-// Wrap `prefix + text` to the given width, bolding the prefix
-function wrapEntry(prefix, text, width) {
-  const lines = wrapText(`${prefix}${text}`, width, INFO_INDENT);
-  if (lines.length > 0) {
-    lines[0] = `{bold}${lines[0].slice(0, prefix.length)}{/bold}${lines[0].slice(prefix.length)}`;
-  }
-  return lines;
-}
-
-function wrapField(field, width) {
-  const label = stripTags(field.label);
-  const value = stripTags(field.value);
-  return value
-    ? wrapEntry(`${label}: `, value, width)
-    : wrapEntry(label, '', width);
-}
-
-// The team notes explain which player each substitute batted or ran for, and
-// are keyed by a letter that appears next to the substitute in the lineup.
-function getNoteLabels(boxscoreTeam, batters, players) {
-  const slotOf = batter => Math.floor(parseInt(batter.battingOrder) / 100);
-  const labels = {};
-  (boxscoreTeam.note || []).forEach(note => {
-    const match = SUBSTITUTE_NOTE.exec(note.value || '');
-    if (!match) {
-      return;
-    }
-    const replacedIdx = batters.findIndex(
-      batter => players[`ID${batter.person.id}`]?.boxscoreName === match[1]
-    );
-    if (replacedIdx < 0) {
-      return;
-    }
-    const slot = slotOf(batters[replacedIdx]);
-    const substitute = batters.find((batter, idx) => (
-      idx > replacedIdx
-      && slotOf(batter) === slot
-      && batter.gameStatus?.isSubstitute
-      && labels[batter.person.id] === undefined
-    ));
-    if (substitute) {
-      labels[substitute.person.id] = note.label;
-    }
-  });
-  return labels;
-}
-
-function getBatterRows(boxscoreTeam, players) {
-  const batters = Object.values(boxscoreTeam.players)
-    .filter(player => player.battingOrder !== undefined)
-    .sort((a, b) => parseInt(a.battingOrder) - parseInt(b.battingOrder));
-  const noteLabels = getNoteLabels(boxscoreTeam, batters, players);
-  const substituteIndent = Object.keys(noteLabels).length > 0 ? '  ' : ' ';
-  const batterNames = batters.map(batter => {
-    const name = players[`ID${batter.person.id}`].boxscoreName;
-    const positions = batter.allPositions?.map(pos => pos.abbreviation).join('-');
-    const label = noteLabels[batter.person.id];
-    let prefix = '';
-    if (label) {
-      prefix = `${label}-`;
-    } else if (batter.gameStatus?.isSubstitute) {
-      prefix = substituteIndent;
-    }
-    return `${prefix}${name} (${positions})`;
-  });
-  return [
-    ...batters.map((batter, idx) => [
-      batterNames[idx],
-      batter.stats.batting.atBats.toString(),
-      batter.stats.batting.runs.toString(),
-      batter.stats.batting.hits.toString(),
-      batter.stats.batting.rbi.toString(),
-      batter.stats.batting.baseOnBalls.toString(),
-      batter.stats.batting.strikeOuts.toString(),
-      batter.seasonStats.batting.avg,
-      batter.seasonStats.batting.ops,
-    ]),
-    [
-      'Totals',
-      boxscoreTeam.teamStats.batting.atBats.toString(),
-      boxscoreTeam.teamStats.batting.runs.toString(),
-      boxscoreTeam.teamStats.batting.hits.toString(),
-      boxscoreTeam.teamStats.batting.rbi.toString(),
-      boxscoreTeam.teamStats.batting.baseOnBalls.toString(),
-      boxscoreTeam.teamStats.batting.strikeOuts.toString(),
-      '',
-      '',
-    ]
-  ];
-}
-
-function getPitcherRows(boxscoreTeam, players) {
-  const pitchers = boxscoreTeam.pitchers.map(pitcherId => boxscoreTeam.players['ID' + pitcherId]);
-  const pitcherNames = pitchers.map(pitcher => {
-    const name = players[`ID${pitcher.person.id}`].boxscoreName;
-    const note = pitcher.stats.pitching.note ? ` ${pitcher.stats.pitching.note}` : '';
-    return `${name}${note}`;
-  });
-  return [
-    ...pitchers.map((pitcher, idx) => [
-      pitcherNames[idx],
-      pitcher.stats.pitching.inningsPitched,
-      pitcher.stats.pitching.hits.toString(),
-      pitcher.stats.pitching.runs.toString(),
-      pitcher.stats.pitching.earnedRuns.toString(),
-      pitcher.stats.pitching.baseOnBalls.toString(),
-      pitcher.stats.pitching.strikeOuts.toString(),
-      pitcher.stats.pitching.homeRuns.toString(),
-      pitcher.seasonStats.pitching.era,
-    ]),
-    [
-      'Totals',
-      boxscoreTeam.teamStats.pitching.inningsPitched,
-      boxscoreTeam.teamStats.pitching.hits.toString(),
-      boxscoreTeam.teamStats.pitching.runs.toString(),
-      boxscoreTeam.teamStats.pitching.earnedRuns.toString(),
-      boxscoreTeam.teamStats.pitching.baseOnBalls.toString(),
-      boxscoreTeam.teamStats.pitching.strikeOuts.toString(),
-      boxscoreTeam.teamStats.pitching.homeRuns.toString(),
-      '',
-    ]
-  ];
-}
-
-// The extra hitting, baserunning and fielding details that appear below a
-// team's batting order: doubles, triples, home runs, stolen bases, errors, etc.
-function getTeamInfoLines(boxscoreTeam, width) {
-  const lines = [];
-  (boxscoreTeam.note || []).forEach(note => {
-    lines.push(...wrapEntry(`${stripTags(note.label)}-`, stripTags(note.value), width));
-  });
-  (boxscoreTeam.info || []).forEach(section => {
-    if (lines.length > 0) {
-      lines.push('');
-    }
-    lines.push(`{bold}${stripTags(section.title)}{/bold}`);
-    (section.fieldList || []).forEach(field => {
-      lines.push(...wrapField(field, width));
-    });
-  });
-  return lines;
-}
-
-// Game wide details that follow the pitching lines: wild pitches, hit
-// batsmen, pitch counts, umpires, weather, attendance, etc.
-function getGameInfoLines(pitchingNotes, gameInfo, width) {
-  const lines = [];
-  (pitchingNotes || []).forEach(note => {
-    lines.push(...wrapText(stripTags(note), width, INFO_INDENT));
-  });
-  if (lines.length > 0 && gameInfo?.length > 0) {
-    lines.push('');
-  }
-  (gameInfo || []).forEach(field => {
-    lines.push(...wrapField(field, width));
-  });
-  return lines;
-}
 
 function InfoBox({ lines, ...rest }) {
   if (lines.length === 0) {
@@ -206,8 +37,8 @@ function BoxScore({ ...props }) {
   const gameInfo = useSelector(selectGameInfo);
   const pitchingNotes = useSelector(selectPitchingNotes);
 
-  // The info sections are wrapped by hand so that the height of each one is
-  // known, which is what everything below it gets positioned against.
+  // The layout depends on how the info text wraps, which depends on how wide
+  // the box score ends up being
   const containerRef = useRef(null);
   const [width, setWidth] = useState(() => getScreen().width);
   const measure = useCallback(() => {
@@ -222,27 +53,20 @@ function BoxScore({ ...props }) {
     screen.on('resize', measure);
     return () => screen.removeListener('resize', measure);
   }, [measure]);
-  const columnWidth = Math.floor(width / 2) - 1;
+
+  const {
+    away,
+    home,
+    gameInfoLines,
+    teamInfoTop,
+    pitcherTop,
+    gameInfoTop,
+  } = getBoxScoreLayout({ boxscore, players, gameInfo, pitchingNotes, width });
 
   const batterHeader = ['Batters', 'AB', 'R', 'H', 'RBI', 'BB', 'K', 'AVG', 'OPS'];
   const batterWidths = ['auto', 4, 4, 4, 4, 4, 4, 6, 6];
-  const awayBatterRows = getBatterRows(boxscore.away, players);
-  const homeBatterRows = getBatterRows(boxscore.home, players);
-
-  const teamInfoStart = Math.max(awayBatterRows.length, homeBatterRows.length) + 2;
-  const awayInfoLines = getTeamInfoLines(boxscore.away, columnWidth);
-  const homeInfoLines = getTeamInfoLines(boxscore.home, columnWidth);
-  const teamInfoHeight = Math.max(awayInfoLines.length, homeInfoLines.length);
-
   const pitcherHeader = ['Pitchers', 'IP', 'H', 'R', 'ER', 'BB', 'K', 'HR', 'ERA'];
   const pitcherWidths = ['auto', 5, 4, 4, 4, 4, 4, 4, 6];
-  const pitcherStart = teamInfoStart + (teamInfoHeight > 0 ? teamInfoHeight + 1 : 0);
-  const awayPitcherRows = getPitcherRows(boxscore.away, players);
-  const homePitcherRows = getPitcherRows(boxscore.home, players);
-
-  const gameInfoStart = pitcherStart
-    + Math.max(awayPitcherRows.length, homePitcherRows.length) + 2;
-  const gameInfoLines = getGameInfoLines(pitchingNotes, gameInfo, width - 1);
 
   return (
     <element
@@ -262,7 +86,7 @@ function BoxScore({ ...props }) {
         width='50%-1'
         headers={batterHeader}
         widths={batterWidths}
-        rows={awayBatterRows}
+        rows={away.batterRows}
       />
       <Table
         top={0}
@@ -270,38 +94,38 @@ function BoxScore({ ...props }) {
         width='50%-1'
         headers={batterHeader}
         widths={batterWidths}
-        rows={homeBatterRows}
+        rows={home.batterRows}
       />
       <InfoBox
-        top={teamInfoStart}
+        top={teamInfoTop}
         left={0}
         width='50%-1'
-        lines={awayInfoLines}
+        lines={away.infoLines}
       />
       <InfoBox
-        top={teamInfoStart}
+        top={teamInfoTop}
         left='50%+1'
         width='50%-1'
-        lines={homeInfoLines}
+        lines={home.infoLines}
       />
       <Table
-        top={pitcherStart}
+        top={pitcherTop}
         left={0}
         width='50%-1'
         headers={pitcherHeader}
         widths={pitcherWidths}
-        rows={awayPitcherRows}
+        rows={away.pitcherRows}
       />
       <Table
-        top={pitcherStart}
+        top={pitcherTop}
         left='50%+1'
         width='50%-1'
         headers={pitcherHeader}
         widths={pitcherWidths}
-        rows={homePitcherRows}
+        rows={home.pitcherRows}
       />
       <InfoBox
-        top={gameInfoStart}
+        top={gameInfoTop}
         left={0}
         width='100%-1'
         lines={gameInfoLines}

--- a/src/components/Table.jsx
+++ b/src/components/Table.jsx
@@ -7,7 +7,7 @@ function formatRow(row, widths) {
     .join('');
 }
 
-function Table({ headers, widths, rows, ...rest }) {
+function Table({ headers, widths, rows, top = 0, ...rest }) {
   const resolvedWidths = widths.map((width, idx) => {
     if (width !== 'auto') {
       return width;
@@ -20,12 +20,14 @@ function Table({ headers, widths, rows, ...rest }) {
   const headerRow = formatRow(headers, resolvedWidths);
   const contentRows = rows.map(row => formatRow(row, resolvedWidths));
 
+  // The header and the rows are siblings rather than children of a wrapping
+  // element so that the table can be scrolled by a scrollable parent. Blessed
+  // only offsets a scrollable element's direct children.
   return (
-    <element {...rest}>
+    <React.Fragment>
       <box
-        top={0}
-        left={0}
-        width='100%'
+        {...rest}
+        top={top}
         height={1}
         fg='black'
         bg='white'
@@ -33,14 +35,13 @@ function Table({ headers, widths, rows, ...rest }) {
         content={headerRow}
       />
       <box
-        top={1}
-        left={0}
-        width='100%'
+        {...rest}
+        top={top + 1}
         height={rows.length}
         wrap={false}
         content={contentRows.join('\n')}
       />
-    </element>
+    </React.Fragment>
   );
 }
 

--- a/src/features/games.js
+++ b/src/features/games.js
@@ -169,9 +169,24 @@ export const selectAllPlays = createSelector(
   plays => plays.allPlays
 );
 
-export const selectBoxscore = createSelector(
+const selectBoxscoreRoot = createSelector(
   selectLiveData,
-  data => data.boxscore?.teams
+  data => data.boxscore
+);
+
+export const selectBoxscore = createSelector(
+  selectBoxscoreRoot,
+  boxscore => boxscore?.teams
+);
+
+export const selectGameInfo = createSelector(
+  selectBoxscoreRoot,
+  boxscore => boxscore?.info
+);
+
+export const selectPitchingNotes = createSelector(
+  selectBoxscoreRoot,
+  boxscore => boxscore?.pitchingNotes
 );
 
 export const selectLineScore = createSelector(

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,6 +11,41 @@ export function teamFavoriteStar(team) {
 }
 
 /**
+ * Break text into lines that fit a given width, indenting every line after
+ * the first. Words longer than the width are split across lines.
+ * @param {string} text
+ * @param {number} width
+ * @param {number} indent number of spaces to prefix continuation lines with
+ * @returns {string[]} the wrapped lines
+ */
+export function wrapText(text, width, indent = 0) {
+  if (width <= 0) {
+    return [text];
+  }
+  const pad = ' '.repeat(Math.min(indent, width - 1));
+  const lines = [];
+  let line = '';
+  text.split(/\s+/).filter(word => word.length > 0).forEach(word => {
+    if (line === '') {
+      line = (lines.length === 0 ? '' : pad) + word;
+    } else if (line.length + 1 + word.length <= width) {
+      line += ' ' + word;
+    } else {
+      lines.push(line);
+      line = pad + word;
+    }
+    while (line.length > width) {
+      lines.push(line.slice(0, width));
+      line = pad + line.slice(width);
+    }
+  });
+  if (line !== '') {
+    lines.push(line);
+  }
+  return lines;
+}
+
+/**
  * Get the sport ID for API calls
  * @returns {string} '51' for WBC, '1' for MLB
  */

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,41 +11,6 @@ export function teamFavoriteStar(team) {
 }
 
 /**
- * Break text into lines that fit a given width, indenting every line after
- * the first. Words longer than the width are split across lines.
- * @param {string} text
- * @param {number} width
- * @param {number} indent number of spaces to prefix continuation lines with
- * @returns {string[]} the wrapped lines
- */
-export function wrapText(text, width, indent = 0) {
-  if (width <= 0) {
-    return [text];
-  }
-  const pad = ' '.repeat(Math.min(indent, width - 1));
-  const lines = [];
-  let line = '';
-  text.split(/\s+/).filter(word => word.length > 0).forEach(word => {
-    if (line === '') {
-      line = (lines.length === 0 ? '' : pad) + word;
-    } else if (line.length + 1 + word.length <= width) {
-      line += ' ' + word;
-    } else {
-      lines.push(line);
-      line = pad + word;
-    }
-    while (line.length > width) {
-      lines.push(line.slice(0, width));
-      line = pad + line.slice(width);
-    }
-  });
-  if (line !== '') {
-    lines.push(line);
-  }
-  return lines;
-}
-
-/**
  * Get the sport ID for API calls
  * @returns {string} '51' for WBC, '1' for MLB
  */

--- a/test/boxScore.test.js
+++ b/test/boxScore.test.js
@@ -1,0 +1,200 @@
+import assert from 'assert';
+
+import {
+  getBatterRows,
+  getBoxScoreLayout,
+  getGameInfoLines,
+  getPitcherRows,
+  getTeamInfoLines,
+  wrapText
+} from '../src/boxScore.js';
+
+assert.deepStrictEqual(wrapText('one two three', 20), ['one two three']);
+assert.deepStrictEqual(wrapText('one two three', 7), ['one two', 'three']);
+assert.deepStrictEqual(wrapText('one two three', 7, 2), ['one two', '  three']);
+assert.deepStrictEqual(wrapText('one   two', 20), ['one two']);
+assert.deepStrictEqual(wrapText('', 20), []);
+// A word too long for the width is split rather than dropped
+assert.deepStrictEqual(wrapText('a bbbbbbbb', 4, 1), ['a', ' bbb', ' bbb', ' bb']);
+// An unmeasurable width is left alone rather than looping forever
+assert.deepStrictEqual(wrapText('one two', 0), ['one two']);
+assert.ok(wrapText('one two three four five', 9, 4).every(line => line.length <= 9));
+
+const battingStats = (stats = {}) => ({
+  stats: {
+    batting: {
+      atBats: 0, runs: 0, hits: 0, rbi: 0, baseOnBalls: 0, strikeOuts: 0, ...stats
+    }
+  },
+  seasonStats: {batting: {avg: '.250', ops: '.700'}},
+});
+const batter = (id, order, positions, options = {}) => ({
+  person: {id},
+  battingOrder: order,
+  allPositions: positions.map(abbreviation => ({abbreviation})),
+  ...battingStats(options.stats),
+  ...(options.substitute ? {gameStatus: {isSubstitute: true}} : {}),
+});
+const pitcher = (id, options = {}) => ({
+  person: {id},
+  stats: {
+    pitching: {
+      inningsPitched: '1.0',
+      hits: 0,
+      runs: 0,
+      earnedRuns: 0,
+      baseOnBalls: 0,
+      strikeOuts: 0,
+      homeRuns: 0,
+      ...options,
+    }
+  },
+  seasonStats: {pitching: {era: '3.00'}},
+});
+const teamStats = {
+  batting: {atBats: 4, runs: 1, hits: 2, rbi: 1, baseOnBalls: 0, strikeOuts: 1},
+  pitching: {
+    inningsPitched: '9.0',
+    hits: 2,
+    runs: 1,
+    earnedRuns: 1,
+    baseOnBalls: 0,
+    strikeOuts: 1,
+    homeRuns: 0,
+  },
+};
+const players = {
+  ID1: {boxscoreName: 'Starter'},
+  ID2: {boxscoreName: 'Pinch'},
+  ID3: {boxscoreName: 'Late'},
+  ID4: {boxscoreName: 'Pitcher'},
+};
+const team = (overrides = {}) => ({
+  players: {
+    ID1: batter(1, '100', ['LF']),
+    ID2: batter(2, '101', ['PH'], {substitute: true}),
+    ID3: batter(3, '200', ['SS']),
+    ID4: pitcher(4),
+  },
+  pitchers: [4],
+  teamStats,
+  ...overrides,
+});
+
+// A substitute is labelled with the note that says who they hit for, and only
+// a substitute in the same lineup spot is a candidate
+const rows = getBatterRows(team({
+  note: [{label: 'a', value: 'Struck out for Starter in the 8th.'}]
+}), players);
+assert.deepStrictEqual(rows.map(row => row[0]), [
+  'Starter (LF)',
+  'a-Pinch (PH)',
+  'Late (SS)',
+  'Totals',
+]);
+assert.deepStrictEqual(
+  getBatterRows(team({
+    note: [{label: 'a', value: 'Struck out for Late in the 8th.'}]
+  }), players).map(row => row[0]),
+  ['Starter (LF)', ' Pinch (PH)', 'Late (SS)', 'Totals']
+);
+// Notes that don't name a batter in the lineup are left unmatched
+assert.deepStrictEqual(
+  getBatterRows(team({
+    note: [{label: 'a', value: 'Struck out for Nobody in the 8th.'}]
+  }), players).map(row => row[0]),
+  ['Starter (LF)', ' Pinch (PH)', 'Late (SS)', 'Totals']
+);
+assert.deepStrictEqual(
+  getBatterRows(team(), players).map(row => row[0]),
+  ['Starter (LF)', ' Pinch (PH)', 'Late (SS)', 'Totals']
+);
+
+assert.deepStrictEqual(
+  getPitcherRows(team({
+    players: {...team().players, ID4: {...pitcher(4), stats: {pitching: {
+      ...pitcher(4).stats.pitching, note: '(W, 1-0)'
+    }}}}
+  }), players).map(row => row[0]),
+  ['Pitcher (W, 1-0)', 'Totals']
+);
+
+// Each section is titled, its labels are bolded, and long values wrap with an
+// indent so they read as one entry
+const infoLines = getTeamInfoLines({
+  note: [{label: 'a', value: 'Struck out for Starter in the 8th.'}],
+  info: [
+    {title: 'BATTING', fieldList: [
+      {label: '2B', value: 'Starter (4, Pitcher).'},
+      {label: 'HR', value: 'Late (12, 9th inning off Pitcher, 0 on, 1 out).'},
+    ]},
+    {title: 'FIELDING', fieldList: [{label: 'E', value: 'Late (3, throw).'}]},
+  ],
+}, 40);
+assert.deepStrictEqual(infoLines, [
+  '{bold}a-{/bold}Struck out for Starter in the 8th.',
+  '',
+  '{bold}BATTING{/bold}',
+  '{bold}2B: {/bold}Starter (4, Pitcher).',
+  '{bold}HR: {/bold}Late (12, 9th inning off Pitcher, 0',
+  '    on, 1 out).',
+  '',
+  '{bold}FIELDING{/bold}',
+  '{bold}E: {/bold}Late (3, throw).',
+]);
+assert.deepStrictEqual(getTeamInfoLines({}, 40), []);
+// Braces would be read as markup by blessed, so they're dropped
+assert.deepStrictEqual(
+  getTeamInfoLines({info: [{title: 'BATTING', fieldList: [{label: '2B', value: 'A {b}'}]}]}, 40),
+  ['{bold}BATTING{/bold}', '{bold}2B: {/bold}A b']
+);
+
+assert.deepStrictEqual(
+  getGameInfoLines(['Pitcher pitched to 2 batters in the 7th.'], [
+    {label: 'WP', value: 'Pitcher.'},
+    {label: 'August 12, 2026'},
+  ], 60),
+  [
+    'Pitcher pitched to 2 batters in the 7th.',
+    '',
+    '{bold}WP: {/bold}Pitcher.',
+    '{bold}August 12, 2026{/bold}',
+  ]
+);
+assert.deepStrictEqual(getGameInfoLines([], [], 60), []);
+assert.deepStrictEqual(
+  getGameInfoLines(['Pitcher pitched to 2 batters in the 7th.'], [], 60),
+  ['Pitcher pitched to 2 batters in the 7th.']
+);
+
+// Sections stack without overlapping, whichever team's is taller
+const layout = getBoxScoreLayout({
+  boxscore: {
+    away: team({info: [{title: 'BATTING', fieldList: [{label: '2B', value: 'Starter (4).'}]}]}),
+    home: team(),
+  },
+  players,
+  gameInfo: [{label: 'WP', value: 'Pitcher.'}],
+  pitchingNotes: [],
+  width: 80,
+});
+assert.strictEqual(layout.away.batterRows.length, 4);
+assert.strictEqual(layout.home.infoLines.length, 0);
+assert.strictEqual(layout.teamInfoTop, layout.away.batterRows.length + 2);
+assert.ok(layout.pitcherTop >= layout.teamInfoTop + layout.away.infoLines.length);
+assert.ok(layout.gameInfoTop >= layout.pitcherTop + layout.away.pitcherRows.length + 1);
+assert.deepStrictEqual(layout.gameInfoLines, ['{bold}WP: {/bold}Pitcher.']);
+
+// With no info at all the pitching lines follow the batting lines directly,
+// the way they did before the details were added
+const bare = getBoxScoreLayout({
+  boxscore: {away: team(), home: team()},
+  players,
+  gameInfo: [],
+  pitchingNotes: [],
+  width: 80,
+});
+assert.strictEqual(bare.pitcherTop, bare.teamInfoTop);
+assert.deepStrictEqual(bare.gameInfoLines, []);
+
+console.log('Box score tests passed');


### PR DESCRIPTION
The box score only had the batting and pitching lines. Add the sections that follow them on a normal box score: the substitution notes, per-team BATTING/BASERUNNING/FIELDING details (2B, 3B, HR, TB, RBI, SB, E, DP, ...), and the game wide pitching and game details (wild pitches, hit batsmen, pitch counts, umpires, weather, attendance, ...).

Substitutes are now prefixed with the letter of the note that explains who they batted or ran for, instead of just being indented.

The info text is wrapped by hand rather than by blessed so that the height of each block is known, since that's what the sections below it are positioned against. The view is now much taller than a terminal, so it scrolls like the plays view does.

Blessed only offsets a scrollable element's direct children, so Table renders its header and rows as siblings rather than wrapping them in an element. Otherwise the tables disappear once they're scrolled.

# Testing

Local testing via docker
<img width="1680" height="1050" alt="Screenshot from 2026-08-13 15-02-59" src="https://github.com/user-attachments/assets/719e1bc9-fed2-49fe-9871-07cfa5d1ae5b" />
<img width="1680" height="1050" alt="Screenshot from 2026-08-13 15-03-17" src="https://github.com/user-attachments/assets/4d538704-cd17-4575-b954-47e09247c641" />
