### PR TITLE
feat: add sort-by-favorites config

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ key | description | default | allowed values
 `color.strike-out` | Color of result where play ends on a strike (strike out) in list of plays in game view | red | _See above_
 `color.walk` | Color of result where play ends on a ball (walk, hit by pitch) in list of plays in game view | green | _See above_
 `favorites` | Teams to highlight in schedule and standings views | | Any one of the following: `ATL`, `AZ`, `BAL`, `BOS`, `CHC`, `CIN`, `CLE`, `COL`, `CWS`, `DET`, `HOU`, `KC`, `LAA`, `LAD`, `MIA`, `MIL`, `MIN`, `NYM`, `NYY`, `OAK`, `PHI`, `PIT`, `SD`, `SEA`, `SF`, `STL`, `TB`, `TEX`, `TOR`, `WSH`. Or a comma-separated list of multiple (e.g. `SEA,MIL`).<br/><br />Note: in some terminals the list must be quoted: `playball config favorites "SEA,MIL"`
+`sort-by-favorites` | Sort games with favorite teams first in the schedule view | `false` | `false`, `true`
 `title` | If enabled, the terminal title will be set to the score of the current game | `false` | `false`, `true`
 `live-delay` | Number of seconds to delay the live game stream. Useful when watching with delayed broadcast streams. | `0` (no delay) | Any positive number
 `sport` | Which sport/league to display | `mlb` | `mlb`, `wbc`

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "babel src --out-dir dist --watch",
     "prepublishOnly": "npm run build",
     "react-devtools": "react-devtools",
-    "test": "node test/gameStatus.test.js && node test/boxScore.test.js"
+    "test": "node --test"
   },
   "bin": {
     "playball": "./bin/playball.js"

--- a/src/components/GameList.jsx
+++ b/src/components/GameList.jsx
@@ -11,7 +11,8 @@ import {
   selectScheduleDate,
   setDate
 } from '../features/schedule.js';
-import {teamFavoriteStar} from '../utils.js';
+import {gameHasFavoriteTeam, teamFavoriteStar} from '../utils.js';
+import {get} from '../config.js';
 import {formatAnnouncedGameTime, formatExceptionalGameStatus} from '../gameStatus.js';
 import {compareGameInnings} from '../gameSort.js';
 import Grid from './Grid.js';
@@ -98,6 +99,16 @@ function compareGameState(a, b) {
 }
 
 function compareGames(a, b) {
+  // Favorites-first: games with at least one favorited team sort before non-favorites
+  if (get('sort-by-favorites')) {
+    const aHasFav = gameHasFavoriteTeam(a);
+    const bHasFav = gameHasFavoriteTeam(b);
+    if (aHasFav !== bHasFav) {
+      return aHasFav ? -1 : 1;
+    }
+  }
+
+  // Then by game state: live -> pre-game -> finished
   const stateCompare = compareGameState(a, b);
   if (stateCompare !== 0) {
     return stateCompare;

--- a/src/components/GameList.jsx
+++ b/src/components/GameList.jsx
@@ -11,10 +11,10 @@ import {
   selectScheduleDate,
   setDate
 } from '../features/schedule.js';
-import {gameHasFavoriteTeam, teamFavoriteStar} from '../utils.js';
+import {teamFavoriteStar} from '../utils.js';
 import {get} from '../config.js';
 import {formatAnnouncedGameTime, formatExceptionalGameStatus} from '../gameStatus.js';
-import {compareGameInnings} from '../gameSort.js';
+import {makeCompareGames} from '../gameSort.js';
 import Grid from './Grid.js';
 import useKey from '../hooks/useKey.js';
 
@@ -89,41 +89,6 @@ const formatGame = (game, scheduleDate) => {
   return content.map(s => ' ' + s).join('\n');
 };
 
-const GAME_STATE_ORDER = {
-  L: 0,
-  P: 1,
-  F: 2,
-};
-function compareGameState(a, b) {
-  return GAME_STATE_ORDER[a.status.abstractGameCode] - GAME_STATE_ORDER[b.status.abstractGameCode];
-}
-
-function compareGames(a, b) {
-  // Favorites-first: games with at least one favorited team sort before non-favorites
-  if (get('sort-by-favorites')) {
-    const aHasFav = gameHasFavoriteTeam(a);
-    const bHasFav = gameHasFavoriteTeam(b);
-    if (aHasFav !== bHasFav) {
-      return aHasFav ? -1 : 1;
-    }
-  }
-
-  // Then by game state: live -> pre-game -> finished
-  const stateCompare = compareGameState(a, b);
-  if (stateCompare !== 0) {
-    return stateCompare;
-  }
-
-  if (a.status.abstractGameCode === 'L') {
-    const inningCompare = compareGameInnings(a, b);
-    if (inningCompare !== 0) {
-      return inningCompare;
-    }
-  }
-
-  return 0;
-}
-
 function GameList({ onGameSelect }) {
   const dispatch = useDispatch();
   const schedule = useSelector(selectData);
@@ -132,6 +97,10 @@ function GameList({ onGameSelect }) {
   const timerRef = useRef(null);
   let games = [];
   if (schedule && schedule.dates.length > 0) {
+    const compareGames = makeCompareGames({
+      sortByFavorites: get('sort-by-favorites'),
+      favorites: get('favorites'),
+    });
     games = schedule.dates[0].games.slice().sort(compareGames);
   }
 

--- a/src/config.js
+++ b/src/config.js
@@ -110,6 +110,10 @@ const schema = {
     },
     default: []
   },
+  'sort-by-favorites': {
+    type: 'boolean',
+    default: false,
+  },
   'title': {
     type: 'boolean',
     default: false,

--- a/src/gameSort.js
+++ b/src/gameSort.js
@@ -1,3 +1,5 @@
+import {gameHasFavoriteTeam} from './utils.js';
+
 export function compareGameInnings(a, b) {
   if (!a.linescore && !b.linescore) {
     return 0;
@@ -20,4 +22,50 @@ export function compareGameInnings(a, b) {
     return 1;
   }
   return 0;
+}
+
+// live -> pre-game -> finished
+const GAME_STATE_ORDER = {
+  L: 0,
+  P: 1,
+  F: 2,
+};
+
+function compareGameState(a, b) {
+  return GAME_STATE_ORDER[a.status.abstractGameCode] - GAME_STATE_ORDER[b.status.abstractGameCode];
+}
+
+/**
+ * Build a comparator for sorting the game list.
+ * @param {object} [options]
+ * @param {boolean} [options.sortByFavorites] - when true, games with at
+ *   least one favorited team sort ahead of games without one
+ * @param {string[]} [options.favorites] - favorited team abbreviations
+ */
+export function makeCompareGames({sortByFavorites = false, favorites = []} = {}) {
+  return (a, b) => {
+    // Favorites-first: games with at least one favorited team sort before non-favorites
+    if (sortByFavorites) {
+      const aHasFav = gameHasFavoriteTeam(a, favorites);
+      const bHasFav = gameHasFavoriteTeam(b, favorites);
+      if (aHasFav !== bHasFav) {
+        return aHasFav ? -1 : 1;
+      }
+    }
+
+    // Then by game state: live -> pre-game -> finished
+    const stateCompare = compareGameState(a, b);
+    if (stateCompare !== 0) {
+      return stateCompare;
+    }
+
+    if (a.status.abstractGameCode === 'L') {
+      const inningCompare = compareGameInnings(a, b);
+      if (inningCompare !== 0) {
+        return inningCompare;
+      }
+    }
+
+    return 0;
+  };
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,10 +1,12 @@
 import { get } from './config.js';
 
 /**
- * Check if a game involves any favorited team
+ * Check if a game involves any favorited team.
+ * @param {object} game
+ * @param {string[]} [favorites] - favorited team abbreviations; defaults to
+ *   the configured favorites when omitted
  */
-export function gameHasFavoriteTeam(game) {
-  const favorites = get('favorites');
+export function gameHasFavoriteTeam(game, favorites = get('favorites')) {
   return favorites.includes(game.teams.away.team.abbreviation) ||
          favorites.includes(game.teams.home.team.abbreviation);
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,10 +1,17 @@
 import { get } from './config.js';
 
-const FAVORITES = get('favorites');
+/**
+ * Check if a game involves any favorited team
+ */
+export function gameHasFavoriteTeam(game) {
+  const favorites = get('favorites');
+  return favorites.includes(game.teams.away.team.abbreviation) ||
+         favorites.includes(game.teams.home.team.abbreviation);
+}
 
 export function teamFavoriteStar(team) {
   const style = get('color.favorite-star') + '-fg';
-  if (FAVORITES.includes(team.abbreviation)) {
+  if (get('favorites').includes(team.abbreviation)) {
     return `{${style}}★{/${style}} `;
   }
   return '';

--- a/test/gameSort.test.js
+++ b/test/gameSort.test.js
@@ -1,48 +1,85 @@
 import {describe, it} from 'node:test';
 import assert from 'node:assert/strict';
 import {gameHasFavoriteTeam} from '../src/utils.js';
+import {makeCompareGames} from '../src/gameSort.js';
+
+function makeGame(id, abstractGameCode, away, home, linescore) {
+  const game = {
+    id,
+    status: {abstractGameCode},
+    teams: {
+      away: {team: {abbreviation: away}},
+      home: {team: {abbreviation: home}}
+    }
+  };
+  if (linescore) {
+    game.linescore = linescore;
+  }
+  return game;
+}
 
 describe('gameHasFavoriteTeam', () => {
-  it('returns false when no team is favorited (default config)', () => {
-    const game = {
-      teams: {
-        away: {team: {abbreviation: 'NYY'}},
-        home: {team: {abbreviation: 'BOS'}}
-      }
-    };
-    assert.strictEqual(gameHasFavoriteTeam(game), false);
+  it('returns false when no team is favorited', () => {
+    const game = makeGame('g', 'P', 'NYY', 'BOS');
+    assert.strictEqual(gameHasFavoriteTeam(game, []), false);
   });
 
-  it('returns true when either team is favorited', () => {
-    const game = {
-      teams: {
-        away: {team: {abbreviation: 'CHC'}},
-        home: {team: {abbreviation: 'CIN'}}
-      }
-    };
-    assert.strictEqual(gameHasFavoriteTeam(game), false);
+  it('returns true when the away team is favorited', () => {
+    const game = makeGame('g', 'P', 'NYY', 'BOS');
+    assert.strictEqual(gameHasFavoriteTeam(game, ['NYY']), true);
+  });
+
+  it('returns true when the home team is favorited', () => {
+    const game = makeGame('g', 'P', 'NYY', 'BOS');
+    assert.strictEqual(gameHasFavoriteTeam(game, ['BOS']), true);
+  });
+
+  it('returns false when favorites contains other teams only', () => {
+    const game = makeGame('g', 'P', 'NYY', 'BOS');
+    assert.strictEqual(gameHasFavoriteTeam(game, ['CHC', 'CIN']), false);
   });
 });
 
-describe('compareGames favorites-first sort', () => {
-  it('documents that live games with no favorites should sort after pre-game favorites', () => {
-    // Expected sort order with sort-by-favorites=true:
-    // 1. Pre-game (NYY vs BOS)       <- has favorite
-    // 2. Finished (LAD vs SD)         <- has favorite
-    // 3. Live (CHC vs CIN)            <- no favorite
-    // 4. Pre-game (DET vs HOU)        <- no favorite
-    assert.ok(true);
+describe('makeCompareGames favorites-first sort', () => {
+  it('sorts a favorite-team game ahead of a non-favorite game, regardless of game state', () => {
+    const preGameFav = makeGame('preGameFav', 'P', 'NYY', 'BOS');
+    const liveNoFav = makeGame('liveNoFav', 'L', 'CHC', 'CIN');
+    const compare = makeCompareGames({sortByFavorites: true, favorites: ['NYY']});
+    const order = [liveNoFav, preGameFav].sort(compare).map(g => g.id);
+    assert.deepStrictEqual(order, ['preGameFav', 'liveNoFav']);
   });
 
-  it('documents that within favorites group, game state still applies', () => {
-    // Within favorited games: live > pre-game > finished
-    // Within non-favorited games: live > pre-game > finished
-    assert.ok(true);
+  it('orders by game state within the favorites group (live > pre-game > finished)', () => {
+    const liveFav = makeGame('liveFav', 'L', 'NYY', 'BOS');
+    const preGameFav = makeGame('preGameFav', 'P', 'LAD', 'SD');
+    const finishedFav = makeGame('finishedFav', 'F', 'CHC', 'CIN');
+    const favorites = ['NYY', 'LAD', 'CHC'];
+    const compare = makeCompareGames({sortByFavorites: true, favorites});
+    const order = [finishedFav, liveFav, preGameFav].sort(compare).map(g => g.id);
+    assert.deepStrictEqual(order, ['liveFav', 'preGameFav', 'finishedFav']);
   });
 
-  it('documents default behavior (sort-by-favorites=false) is unchanged', () => {
-    // Default sort: by game state only, then inning depth for live games
-    // Favorites have no effect on ordering
-    assert.ok(true);
+  it('ignores favorites when sortByFavorites is false, ordering by game state only', () => {
+    const liveNoFav = makeGame('liveNoFav', 'L', 'DET', 'HOU');
+    const preGameFav = makeGame('preGameFav', 'P', 'NYY', 'BOS');
+    const compare = makeCompareGames({sortByFavorites: false, favorites: ['NYY']});
+    const order = [preGameFav, liveNoFav].sort(compare).map(g => g.id);
+    assert.deepStrictEqual(order, ['liveNoFav', 'preGameFav']);
+  });
+
+  it('defaults to sortByFavorites off and no favorites when called with no options', () => {
+    const liveGame = makeGame('live', 'L', 'DET', 'HOU');
+    const preGameFav = makeGame('preGameFav', 'P', 'NYY', 'BOS');
+    const compare = makeCompareGames();
+    const order = [preGameFav, liveGame].sort(compare).map(g => g.id);
+    assert.deepStrictEqual(order, ['live', 'preGameFav']);
+  });
+
+  it('breaks ties between two live games by inning depth', () => {
+    const earlyInning = makeGame('early', 'L', 'DET', 'HOU', {currentInning: 2});
+    const lateInning = makeGame('late', 'L', 'NYY', 'BOS', {currentInning: 8});
+    const compare = makeCompareGames();
+    const order = [earlyInning, lateInning].sort(compare).map(g => g.id);
+    assert.deepStrictEqual(order, ['late', 'early']);
   });
 });

--- a/test/gameSort.test.js
+++ b/test/gameSort.test.js
@@ -1,0 +1,48 @@
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import {gameHasFavoriteTeam} from '../src/utils.js';
+
+describe('gameHasFavoriteTeam', () => {
+  it('returns false when no team is favorited (default config)', () => {
+    const game = {
+      teams: {
+        away: {team: {abbreviation: 'NYY'}},
+        home: {team: {abbreviation: 'BOS'}}
+      }
+    };
+    assert.strictEqual(gameHasFavoriteTeam(game), false);
+  });
+
+  it('returns true when either team is favorited', () => {
+    const game = {
+      teams: {
+        away: {team: {abbreviation: 'CHC'}},
+        home: {team: {abbreviation: 'CIN'}}
+      }
+    };
+    assert.strictEqual(gameHasFavoriteTeam(game), false);
+  });
+});
+
+describe('compareGames favorites-first sort', () => {
+  it('documents that live games with no favorites should sort after pre-game favorites', () => {
+    // Expected sort order with sort-by-favorites=true:
+    // 1. Pre-game (NYY vs BOS)       <- has favorite
+    // 2. Finished (LAD vs SD)         <- has favorite
+    // 3. Live (CHC vs CIN)            <- no favorite
+    // 4. Pre-game (DET vs HOU)        <- no favorite
+    assert.ok(true);
+  });
+
+  it('documents that within favorites group, game state still applies', () => {
+    // Within favorited games: live > pre-game > finished
+    // Within non-favorited games: live > pre-game > finished
+    assert.ok(true);
+  });
+
+  it('documents default behavior (sort-by-favorites=false) is unchanged', () => {
+    // Default sort: by game state only, then inning depth for live games
+    // Favorites have no effect on ordering
+    assert.ok(true);
+  });
+});


### PR DESCRIPTION
## feat: add sort-by-favorites config to prioritize favorite teams' games

### Changes

- **`src/config.js`** — Add `sort-by-favorites` boolean config key (default `false`)
- **`src/utils.js`** — Add `gameHasFavoriteTeam(game)` helper that reads favorites dynamically
- **`src/components/GameList.jsx`** — Wire favorites-first into `compareGames()`; favorited teams bubble to top, original sort still applies within groups
- **`test/gameSort.test.js`** — New test file for sort behavior
- **`package.json`** — Update `test` script from manual file list to `node --test` (auto-discovers all `*.test.js`)
- **`README.md`** — Document the new config in the settings table

### Usage

```bash
playball config favorites NYY,LAD,TB
playball config sort-by-favorites true
playball today
```