### PR TITLE
feat: add sort-by-favorites config to prioritize favorite teams' games

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ key | description | default | allowed values
 `color.strike-out` | Color of result where play ends on a strike (strike out) in list of plays in game view | red | _See above_
 `color.walk` | Color of result where play ends on a ball (walk, hit by pitch) in list of plays in game view | green | _See above_
 `favorites` | Teams to highlight in schedule and standings views | | Any one of the following: `ATL`, `AZ`, `BAL`, `BOS`, `CHC`, `CIN`, `CLE`, `COL`, `CWS`, `DET`, `HOU`, `KC`, `LAA`, `LAD`, `MIA`, `MIL`, `MIN`, `NYM`, `NYY`, `OAK`, `PHI`, `PIT`, `SD`, `SEA`, `SF`, `STL`, `TB`, `TEX`, `TOR`, `WSH`. Or a comma-separated list of multiple (e.g. `SEA,MIL`).<br/><br />Note: in some terminals the list must be quoted: `playball config favorites "SEA,MIL"`
+`sort-by-favorites` | Sort games with favorite teams first in the schedule view | `false` | `false`, `true`
 `title` | If enabled, the terminal title will be set to the score of the current game | `false` | `false`, `true`
 `live-delay` | Number of seconds to delay the live game stream. Useful when watching with delayed broadcast streams. | `0` (no delay) | Any positive number
 `sport` | Which sport/league to display | `mlb` | `mlb`, `wbc`

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "start": "babel src --out-dir dist --watch",
     "prepublishOnly": "npm run build",
     "react-devtools": "react-devtools",
-    "test": "node test/gameStatus.test.js && node test/boxScore.test.js"
+    "test": "node --test"
   },
   "bin": {
     "playball": "./bin/playball.js"

--- a/src/cli.js
+++ b/src/cli.js
@@ -38,7 +38,7 @@ program.command('config')
         console.log(`${key} = ${value}`);
       }
     } else if (!value) {
-      console.log(config.get(key));
+      console.log(config.serialize(config.get(key)));
     } else {
       config.set(key, value);
     }

--- a/src/components/GameList.jsx
+++ b/src/components/GameList.jsx
@@ -12,8 +12,9 @@ import {
   setDate
 } from '../features/schedule.js';
 import {teamFavoriteStar} from '../utils.js';
+import {get} from '../config.js';
 import {formatAnnouncedGameTime, formatExceptionalGameStatus} from '../gameStatus.js';
-import {compareGameInnings} from '../gameSort.js';
+import {makeCompareGames} from '../gameSort.js';
 import Grid from './Grid.js';
 import useKey from '../hooks/useKey.js';
 
@@ -88,31 +89,6 @@ const formatGame = (game, scheduleDate) => {
   return content.map(s => ' ' + s).join('\n');
 };
 
-const GAME_STATE_ORDER = {
-  L: 0,
-  P: 1,
-  F: 2,
-};
-function compareGameState(a, b) {
-  return GAME_STATE_ORDER[a.status.abstractGameCode] - GAME_STATE_ORDER[b.status.abstractGameCode];
-}
-
-function compareGames(a, b) {
-  const stateCompare = compareGameState(a, b);
-  if (stateCompare !== 0) {
-    return stateCompare;
-  }
-
-  if (a.status.abstractGameCode === 'L') {
-    const inningCompare = compareGameInnings(a, b);
-    if (inningCompare !== 0) {
-      return inningCompare;
-    }
-  }
-
-  return 0;
-}
-
 function GameList({ onGameSelect }) {
   const dispatch = useDispatch();
   const schedule = useSelector(selectData);
@@ -121,6 +97,10 @@ function GameList({ onGameSelect }) {
   const timerRef = useRef(null);
   let games = [];
   if (schedule && schedule.dates.length > 0) {
+    const compareGames = makeCompareGames({
+      sortByFavorites: get('sort-by-favorites'),
+      favorites: get('favorites'),
+    });
     games = schedule.dates[0].games.slice().sort(compareGames);
   }
 

--- a/src/config.js
+++ b/src/config.js
@@ -110,6 +110,10 @@ const schema = {
     },
     default: []
   },
+  'sort-by-favorites': {
+    type: 'boolean',
+    default: false,
+  },
   'title': {
     type: 'boolean',
     default: false,
@@ -131,10 +135,10 @@ const config = new Conf({
   schema,
 });
 
-function serialize(value) {
+export function serialize(value) {
   if (value && Array.isArray(value)) {
     return value.join(',');
-  } 
+  }
   return value;
 }
 
@@ -150,7 +154,7 @@ function deserialize(key, value) {
 }
 
 export function get(key) {
-  return serialize(config.get(key));
+  return config.get(key);
 }
 
 export function set(key, value) {

--- a/src/gameSort.js
+++ b/src/gameSort.js
@@ -1,3 +1,5 @@
+import {gameHasFavoriteTeam} from './utils.js';
+
 export function compareGameInnings(a, b) {
   if (!a.linescore && !b.linescore) {
     return 0;
@@ -13,11 +15,63 @@ export function compareGameInnings(a, b) {
   if (inningCompare !== 0) {
     return inningCompare;
   }
-  if (a.isTopInning && !b.isTopInning) {
-    return -1;
-  }
-  if (b.isTopInning && !a.isTopInning) {
+  // isTopInning lives on the linescore, not the game itself. Within the same
+  // inning number, the bottom half is further along than the top half, so it
+  // should sort first to stay consistent with "deepest game first".
+  if (a.linescore.isTopInning && !b.linescore.isTopInning) {
     return 1;
   }
+  if (b.linescore.isTopInning && !a.linescore.isTopInning) {
+    return -1;
+  }
   return 0;
+}
+
+// live -> pre-game -> finished
+const GAME_STATE_ORDER = {
+  L: 0,
+  P: 1,
+  F: 2,
+};
+
+function compareGameState(a, b) {
+  return GAME_STATE_ORDER[a.status.abstractGameCode] - GAME_STATE_ORDER[b.status.abstractGameCode];
+}
+
+/**
+ * Build a comparator for sorting the game list.
+ * @param {object} [options]
+ * @param {boolean} [options.sortByFavorites] - when true, games with at
+ *   least one favorited team sort ahead of games without one
+ * @param {string[]} [options.favorites] - favorited team abbreviations
+ */
+export function makeCompareGames({sortByFavorites = false, favorites = []} = {}) {
+  return (a, b) => {
+    // Favorites-first: games with at least one favorited team sort before non-favorites
+    if (sortByFavorites) {
+      const aHasFav = gameHasFavoriteTeam(a, favorites);
+      const bHasFav = gameHasFavoriteTeam(b, favorites);
+      if (aHasFav !== bHasFav) {
+        return aHasFav ? -1 : 1;
+      }
+    }
+
+    // Then by game state: live -> pre-game -> finished
+    const stateCompare = compareGameState(a, b);
+    if (stateCompare !== 0) {
+      return stateCompare;
+    }
+
+    // Finally, break ties between two live games by inning depth, so the
+    // games furthest along appear first. Only live games have an inning to
+    // compare, so pre-game and finished games keep their existing order.
+    if (a.status.abstractGameCode === 'L') {
+      const inningCompare = compareGameInnings(a, b);
+      if (inningCompare !== 0) {
+        return inningCompare;
+      }
+    }
+
+    return 0;
+  };
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,10 +1,18 @@
 import { get } from './config.js';
 
-const FAVORITES = get('favorites');
+/**
+ * Check if a game involves any favorited team.
+ * @param {object} game
+ * @param {string[]} favorites - favorited team abbreviations
+ */
+export function gameHasFavoriteTeam(game, favorites) {
+  return favorites.includes(game.teams.away.team.abbreviation) ||
+         favorites.includes(game.teams.home.team.abbreviation);
+}
 
 export function teamFavoriteStar(team) {
   const style = get('color.favorite-star') + '-fg';
-  if (FAVORITES.includes(team.abbreviation)) {
+  if (get('favorites').includes(team.abbreviation)) {
     return `{${style}}★{/${style}} `;
   }
   return '';

--- a/test/gameSort.test.js
+++ b/test/gameSort.test.js
@@ -1,0 +1,89 @@
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import {makeCompareGames} from '../src/gameSort.js';
+
+function makeGame(id, abstractGameCode, away, home, linescore) {
+  const game = {
+    id,
+    status: {abstractGameCode},
+    teams: {
+      away: {team: {abbreviation: away}},
+      home: {team: {abbreviation: home}}
+    }
+  };
+  if (linescore) {
+    game.linescore = linescore;
+  }
+  return game;
+}
+
+describe('makeCompareGames favorites-first sort', () => {
+  it('sorts a full matrix of favorite/non-favorite x live/pre-game/finished games', () => {
+    // Favorites: NYY, LAD
+    const liveFav = makeGame('liveFav', 'L', 'NYY', 'BOS', {currentInning: 5, isTopInning: false});
+    const preGameFav = makeGame('preGameFav', 'P', 'LAD', 'SD');
+    const finishedFav = makeGame('finishedFav', 'F', 'NYY', 'CIN');
+    const liveNoFav = makeGame('liveNoFav', 'L', 'CHC', 'MIL', {currentInning: 3, isTopInning: true});
+    const preGameNoFav = makeGame('preGameNoFav', 'P', 'DET', 'HOU');
+    const finishedNoFav = makeGame('finishedNoFav', 'F', 'SEA', 'TEX');
+
+    const favorites = ['NYY', 'LAD'];
+    const compare = makeCompareGames({sortByFavorites: true, favorites});
+
+    // Adversarial input order: not sorted, not reversed.
+    const shuffled = [
+      preGameNoFav,
+      finishedFav,
+      liveNoFav,
+      liveFav,
+      finishedNoFav,
+      preGameFav
+    ];
+
+    const order = shuffled.sort(compare).map(g => g.id);
+    assert.deepStrictEqual(order, [
+      'liveFav',
+      'preGameFav',
+      'finishedFav',
+      'liveNoFav',
+      'preGameNoFav',
+      'finishedNoFav'
+    ]);
+  });
+
+  it('ignores favorites when sortByFavorites is false, ordering by game state only', () => {
+    const liveNoFav = makeGame('liveNoFav', 'L', 'DET', 'HOU');
+    const preGameFav = makeGame('preGameFav', 'P', 'NYY', 'BOS');
+    const compare = makeCompareGames({sortByFavorites: false, favorites: ['NYY']});
+    const order = [preGameFav, liveNoFav].sort(compare).map(g => g.id);
+    assert.deepStrictEqual(order, ['liveNoFav', 'preGameFav']);
+  });
+
+  it('defaults to sortByFavorites off and no favorites when called with no options', () => {
+    const liveGame = makeGame('live', 'L', 'DET', 'HOU');
+    const preGameFav = makeGame('preGameFav', 'P', 'NYY', 'BOS');
+    const compare = makeCompareGames();
+    const order = [preGameFav, liveGame].sort(compare).map(g => g.id);
+    assert.deepStrictEqual(order, ['live', 'preGameFav']);
+  });
+
+  it('breaks ties between live games by inning depth', () => {
+    const earlyInning = makeGame('early', 'L', 'DET', 'HOU', {currentInning: 2});
+    const midInning = makeGame('mid', 'L', 'SEA', 'TEX', {currentInning: 5});
+    const lateInning = makeGame('late', 'L', 'NYY', 'BOS', {currentInning: 8});
+    const compare = makeCompareGames();
+    // Adversarial input order: not sorted, not reversed.
+    const order = [midInning, lateInning, earlyInning].sort(compare).map(g => g.id);
+    assert.deepStrictEqual(order, ['late', 'mid', 'early']);
+  });
+
+  it('breaks ties between two live games in the same inning by top/bottom half', () => {
+    // Same inning number: the bottom half is further along than the top half,
+    // so it should sort first (consistent with "deepest game first").
+    const topOfInning = makeGame('top', 'L', 'DET', 'HOU', {currentInning: 5, isTopInning: true});
+    const bottomOfInning = makeGame('bottom', 'L', 'NYY', 'BOS', {currentInning: 5, isTopInning: false});
+    const compare = makeCompareGames();
+    const order = [topOfInning, bottomOfInning].sort(compare).map(g => g.id);
+    assert.deepStrictEqual(order, ['bottom', 'top']);
+  });
+});

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,44 @@
+import {describe, it} from 'node:test';
+import assert from 'node:assert/strict';
+import {gameHasFavoriteTeam} from '../src/utils.js';
+
+function makeGame(away, home) {
+  return {
+    teams: {
+      away: {team: {abbreviation: away}},
+      home: {team: {abbreviation: home}}
+    }
+  };
+}
+
+describe('gameHasFavoriteTeam', () => {
+  it('returns false when no team is favorited', () => {
+    const game = makeGame('NYY', 'BOS');
+    assert.strictEqual(gameHasFavoriteTeam(game, []), false);
+  });
+
+  it('returns true when the away team is favorited', () => {
+    const game = makeGame('NYY', 'BOS');
+    assert.strictEqual(gameHasFavoriteTeam(game, ['NYY']), true);
+  });
+
+  it('returns true when the home team is favorited', () => {
+    const game = makeGame('NYY', 'BOS');
+    assert.strictEqual(gameHasFavoriteTeam(game, ['BOS']), true);
+  });
+
+  it('returns false when favorites contains other teams only', () => {
+    const game = makeGame('NYY', 'BOS');
+    assert.strictEqual(gameHasFavoriteTeam(game, ['CHC', 'CIN']), false);
+  });
+
+  it('does exact matching, not substring matching, on team abbreviations', () => {
+    // 'NY' is a substring of 'NYY' but is not itself a valid team abbreviation.
+    // Under the old (buggy) behavior where favorites was a comma-joined string,
+    // String.prototype.includes would have matched this via substring search.
+    // With favorites as a real array, Array.prototype.includes must require an
+    // exact element match and must NOT match here.
+    const game = makeGame('NYY', 'BOS');
+    assert.strictEqual(gameHasFavoriteTeam(game, ['NY']), false);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a `sort-by-favorites` config option that, when enabled, sorts games with at least one favorited team ahead of games without one in the game list. Within each group (favorites / non-favorites), the existing ordering still applies: live > pre-game > finished, with live games further ordered by inning depth.

## Changes
- New `sort-by-favorites` boolean config key, default `false`, documented in the README config table.
- Added `gameHasFavoriteTeam(game, favorites)` in `utils.js`, taking favorites as an explicit parameter so it is testable in isolation.
- Moved the game-list comparator from `GameList.jsx` into an exported `makeCompareGames({sortByFavorites, favorites})` factory in `gameSort.js`. `GameList.jsx` builds the comparator from config at render time and passes it to `sort`.
- `teamFavoriteStar` reads `favorites` per call instead of caching it in a module-level constant at import, so a config change takes effect without a restart.
- `config.get()` returns the value in its declared schema type instead of joining arrays into a string, so `get('favorites')` yields `['SD','NYY']` and favorite lookups match exact abbreviations rather than substrings. `serialize()` is exported and applied at the CLI display site, so `playball config favorites` still prints `SD,NYY`.
- `compareGameInnings` breaks ties between live games in the same inning by half-inning, reading `isTopInning` from the linescore: the bottom half sorts ahead of the top half, consistent with the function's descending "deepest game first" ordering.
- `npm test` now runs `node --test` so the whole `test/` directory is picked up, rather than naming two files explicitly.
- Tests in `test/gameSort.test.js` cover favorites-first ordering across a six-game favorite/non-favorite × live/pre-game/finished matrix, favorites ignored when the flag is off, comparator defaults, inning-depth tiebreak, and the same-inning top/bottom-half tiebreak. `test/utils.test.js` covers `gameHasFavoriteTeam`, including that `['NY']` does not match a game with `'NYY'`.

## Testing
- `npm test` — 12/12 passing
- `npm run lint` — clean
